### PR TITLE
Step17: タスク優先度の追加

### DIFF
--- a/app/graphql/mutations/create_task.rb
+++ b/app/graphql/mutations/create_task.rb
@@ -2,10 +2,11 @@ module Mutations
   class CreateTask < BaseMutation
     field :task,   Types::TaskType, null: false
 
-    argument :title,       String, required: true
-    argument :description, String, required: false
-    argument :deadline,    String, required: false
-    argument :done_id,     ID,     required: false
+    argument :title,           String, required: true
+    argument :description,     String, required: false
+    argument :deadline,        String, required: false
+    argument :done_id,         ID,     required: false
+    argument :priority_number, Int,    required: false
 
     def resolve(**args)
       task = Task.create!(args)

--- a/app/graphql/mutations/update_task.rb
+++ b/app/graphql/mutations/update_task.rb
@@ -2,11 +2,12 @@ module Mutations
   class UpdateTask < BaseMutation
     field :task,   Types::TaskType, null: true
 
-    argument :id,          ID,     required: true
-    argument :title,       String, required: false
-    argument :description, String, required: false
-    argument :deadline,    String, required: false
-    argument :done_id,     ID,     required: false
+    argument :id,              ID,     required: true
+    argument :title,           String, required: false
+    argument :description,     String, required: false
+    argument :deadline,        String, required: false
+    argument :done_id,         ID,     required: false
+    argument :priority_number, Int,    required: false
 
     def resolve(**args)
       task = Task.find(args[:id])

--- a/app/graphql/types/task_type.rb
+++ b/app/graphql/types/task_type.rb
@@ -5,6 +5,7 @@ module Types
     field :description, String, null: false
     field :done, DoneType, null: false
     field :done_id, ID, null: false
+    field :priority_number, Int, null: false
     field :deadline, GraphQL::Types::ISO8601DateTime, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/javascript/components/common/Priority.js
+++ b/app/javascript/components/common/Priority.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Chip from '@mui/material/Chip';
+
+const TEXTS = ['低', '中', '高'];
+const COLORS = ['default', 'warning', 'error'];
+
+const Priority = (props) => {
+  return (
+    <Chip
+      label={TEXTS[props.priority]}
+      color={COLORS[props.priority]}
+      size="small" 
+      sx={{ marginRight: '10px' }}
+    />
+  );
+};
+
+export default Priority;

--- a/app/javascript/components/common/PriorityForm.js
+++ b/app/javascript/components/common/PriorityForm.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Box from '@mui/material/Box';
 import InputLabel from '@mui/material/InputLabel';
@@ -8,6 +8,10 @@ import Select from '@mui/material/Select';
 
 const PriorityForm = (props) => {
   const [priority, setPriority] = useState(props.defaultValue);
+
+  useEffect(() => {
+    props.setValue('priorityNumber', priority);
+  }, []);
 
   const handleChange = (event) => {
     setPriority(event.target.value);

--- a/app/javascript/components/common/PriorityForm.js
+++ b/app/javascript/components/common/PriorityForm.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import Box from '@mui/material/Box';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select from '@mui/material/Select';
+
+const PriorityForm = (props) => {
+  const [priority, setPriority] = useState(props.defaultValue);
+
+  const handleChange = (event) => {
+    setPriority(event.target.value);
+    props.setValue('priorityNumber', event.target.value);
+  };
+
+  return (
+    <Box sx={{ minWidth: 120 }}>
+      <FormControl fullWidth>
+        <InputLabel id="status-label">優先度</InputLabel>
+        <Select
+          labelId="status-label"
+          value={priority}
+          label="優先度"
+          onChange={handleChange}
+        >
+          <MenuItem value="0">低</MenuItem>
+          <MenuItem value="1">中</MenuItem>
+          <MenuItem value="2">高</MenuItem>
+        </Select>
+      </FormControl>
+    </Box>
+  );
+};
+
+export default PriorityForm

--- a/app/javascript/components/common/SearchForm.js
+++ b/app/javascript/components/common/SearchForm.js
@@ -44,6 +44,7 @@ const SearchForm = (props) => {
               id
               text
             }
+            priorityNumber
             createdAt
           }
         }

--- a/app/javascript/components/common/SortForm.js
+++ b/app/javascript/components/common/SortForm.js
@@ -36,9 +36,15 @@ const SortForm = (props) => {
             <ArrowToggleIcon isAsc={props.isAsc} />
           }
         </ToggleButton>
-        <ToggleButton value="deadline" sx={{ width: '80px' }}>
+        <ToggleButton value="deadline" sx={{ width: '100px' }}>
           期限
           {props.sortType === 'deadline' &&
+            <ArrowToggleIcon isAsc={props.isAsc} />
+          }
+        </ToggleButton>
+        <ToggleButton value="priorityNumber" sx={{ width: '100px' }}>
+          優先度
+          {props.sortType === 'priorityNumber' &&
             <ArrowToggleIcon isAsc={props.isAsc} />
           }
         </ToggleButton>

--- a/app/javascript/components/common/TaskForm.js
+++ b/app/javascript/components/common/TaskForm.js
@@ -10,8 +10,10 @@ import TaskCard from "common/TaskCard";
 import FormItem from "common/FormItem";
 import DeadLine from "common/DeadLine";
 import DoneForm from "common/DoneForm";
+import PriorityForm from "common/PriorityForm";
 import { useForm } from 'react-hook-form';
 import Button from '@mui/material/Button';
+import { Grid } from "@mui/material";
 
 const TaskForm = (props) => {
   const { register, handleSubmit, formState: { errors }, setValue } = useForm();
@@ -52,10 +54,20 @@ const TaskForm = (props) => {
             />
           </FormItem>
           <FormItem>
-            <DoneForm
-              setValue={setValue}
-              defaultValue={props.task.done?.id || '-1'}
-            />
+            <Grid container spacing={2}>
+              <Grid item xs={6}>
+                <PriorityForm
+                  setValue={setValue}
+                  defaultValue={props.task.priorityNumber || '0'}
+                />
+              </Grid>
+              <Grid item xs={6}>
+                <DoneForm
+                  setValue={setValue}
+                  defaultValue={props.task.done?.id || '-1'}
+                />
+              </Grid>
+            </Grid>
           </FormItem>
         </CardContent>
         <CardActions>

--- a/app/javascript/components/page/TaskEdit.js
+++ b/app/javascript/components/page/TaskEdit.js
@@ -25,6 +25,7 @@ const TaskEdit = () => {
             done {
               id
             }
+            priorityNumber
             createdAt
           }
         }
@@ -49,6 +50,7 @@ const TaskEdit = () => {
               description: "${data.description}"
               deadline: "${data.deadline}"
               doneId: "${data.done_id}"
+              priorityNumber: ${data.priorityNumber}
             }
           ){
             task {

--- a/app/javascript/components/page/TaskPost.js
+++ b/app/javascript/components/page/TaskPost.js
@@ -20,6 +20,7 @@ const TaskPost = () => {
               description: "${data.description}"
               deadline: "${data.deadline}"
               doneId: "${data.done_id}"
+              priorityNumber: ${data.priorityNumber}
             }
           ) {
             task {

--- a/app/javascript/components/page/Top.js
+++ b/app/javascript/components/page/Top.js
@@ -105,7 +105,11 @@ const Top = () => {
   };
 
   // タスク一覧のソート処理
-  const getValueForSort = sortType => task => dayjs(task[sortType] || '2100-01-01'); // 期限が設定されていないものは遥か未来として扱う
+  const getValueForSort = (sortType) => {
+    return sortType == 'priorityNumber' ? 
+      (task) => task.priorityNumber :
+      (task) => dayjs(task[sortType] || '2100-01-01');// 期限が設定されていないものは遥か未来として扱う
+  };
   const handleChangeSort = (sortType, isAsc) => {
     const f = getValueForSort(sortType);
     const n = isAsc ? 1 : -1;

--- a/app/javascript/components/page/Top.js
+++ b/app/javascript/components/page/Top.js
@@ -17,6 +17,7 @@ import ConfirmDialog from 'common/ConfirmDialog';
 import FlashMessage from 'common/FlashMessage';
 import SortForm from 'common/SortForm';
 import SearchForm from 'common/SearchForm';
+import Priority from 'common/Priority';
 import { DATETIME_FORMAT } from 'utils/constants';
 
 const DoneChip = (props) => {
@@ -53,6 +54,7 @@ const Top = () => {
               id
               text
             }
+            priorityNumber
             createdAt
           }
         }
@@ -136,7 +138,10 @@ const Top = () => {
           <CardHeader
             title={
               <Box style={{ display: 'flex', justifyContent: 'space-between' }}>
-                <div>{task.title}</div>
+                <div>
+                  <Priority priority={task.priorityNumber} />
+                  {task.title}
+                </div>
                 <div>
                   <DoneChip done={task.done} />
                 </div>

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,6 +4,7 @@ class Task < ApplicationRecord
 
   validates :title, presence: true
   validates :done_id, inclusion: { in: Done.pluck(:id) }
+  validates :priority_number, inclusion: { in: [0, 1, 2] }
 
   def self.search(word:, target:, done_ids:, sort_type:, is_asc:)
     sort_key = sort_type.underscore # スネークケースに変換

--- a/db/migrate/20211116054956_add_priority_number_to_tasks.rb
+++ b/db/migrate/20211116054956_add_priority_number_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddPriorityNumberToTasks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tasks, :priority_number, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_16_020044) do
+ActiveRecord::Schema.define(version: 2021_11_16_054956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2021_11_16_020044) do
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "deadline"
     t.integer "done_id", default: -1, null: false
+    t.integer "priority_number", default: 0, null: false
     t.index ["created_at"], name: "index_tasks_on_created_at"
     t.index ["deadline"], name: "index_tasks_on_deadline"
     t.index ["done_id"], name: "index_tasks_on_done_id"

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     description { Faker::Lorem.sentence }
     deadline { '2021-01-01 00:00:00' }
     done_id { Done.pluck(:id).sample }
+    priority_number { [0, 1, 2].sample }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe Task, type: :model do
         let(:params) { { done_id: 2 } }
         it { is_expected.to include('Done is not included in the list') }
       end
+
+      context 'タスクのステータスが0,1,2以外の時' do
+        let(:params) { { priority_number: 3 } }
+        it { is_expected.to include('Priority number is not included in the list') }
+      end
     end
   end
 

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -185,9 +185,9 @@ RSpec.describe 'Tasks', type: :system do
   describe 'タスク一覧の並び順' do
     let!(:tasks) {
       [
-        FactoryBot.create(:task, created_at: '2021-11-01 00:00:00', deadline: '2021-11-02 00:00:00'),
-        FactoryBot.create(:task, created_at: '2021-11-02 00:00:00', deadline: '2021-11-01 00:00:00'),
-        FactoryBot.create(:task, created_at: '2021-11-03 00:00:00', deadline: '2021-11-03 00:00:00')
+        FactoryBot.create(:task, created_at: '2021-11-01 00:00:00', deadline: '2021-11-02 00:00:00', priority_number: 1),
+        FactoryBot.create(:task, created_at: '2021-11-02 00:00:00', deadline: '2021-11-01 00:00:00', priority_number: 2),
+        FactoryBot.create(:task, created_at: '2021-11-03 00:00:00', deadline: '2021-11-03 00:00:00', priority_number: 0)
       ]
     }
 
@@ -231,6 +231,28 @@ RSpec.describe 'Tasks', type: :system do
       }
       it '期限昇順に並びが変わる' do
         expect(subject).to match /#{tasks[1].title}.*#{tasks[0].title}.*#{tasks[2].title}/
+      end
+    end
+
+    context '優先度の並べ替えボタンをクリックしたとき' do
+      subject {
+        visit root_path
+        click_button '優先度'
+        page.body
+      }
+      it '優先度降順に並びが変わる' do
+        expect(subject).to match /#{tasks[1].title}.*#{tasks[0].title}.*#{tasks[2].title}/
+      end
+    end
+
+    context '優先度の並べ替えボタンを2回クリックしたとき' do
+      subject {
+        visit root_path
+        2.times { click_button '優先度' }
+        page.body
+      }
+      it '優先度昇順に並びが変わる' do
+        expect(subject).to match /#{tasks[2].title}.*#{tasks[0].title}.*#{tasks[1].title}/
       end
     end
   end


### PR DESCRIPTION
* タスク優先度(高/中/低)を設定できるようにしました。
  * 優先度は任意の値を入力できるようにする等の仕様変更を想定し、ActiveHashで優先度モデルを作成せずに`integer`型にしました。
  * バリデーションで`2`/`1`/`0`のみ(高/中/低)を挿入できるように制限しました。
* タスク一覧画面で優先度でソートできるようにしました。

自動テストも拡充し、herokuも更新しました。
https://miyatani-el-training.herokuapp.com/
よろしくお願いします！
