### PR TITLE
Step24: タスクに複数のラベルをつけられるようにする

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,8 +1,4 @@
 class GraphqlController < ApplicationController
-  class AuthorizationError < StandardError; end
-
-  class AdminAuthorizationError < StandardError; end
-
   def execute
     variables = prepare_variables(params[:variables])
     query = params[:query]
@@ -12,9 +8,9 @@ class GraphqlController < ApplicationController
     }
     result = MiyataniElTrainingSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
-  rescue AuthorizationError
+  rescue Application::AuthorizationError
     render json: { error: { message: 'Authorization Error' } }, status: :forbidden
-  rescue AdminAuthorizationError
+  rescue Application::AdminAuthorizationError
     render json: { error: { message: 'Admin Authorization Error' } }, status: :forbidden
   rescue => e
     render json: { errors: [{ message: e.message }], data: {} }, status: :bad_request

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,4 +1,5 @@
 class GraphqlController < ApplicationController
+  class AuthorizationError < StandardError; end
   class AdminAuthorizationError < StandardError; end
 
   def execute
@@ -6,11 +7,12 @@ class GraphqlController < ApplicationController
     query = params[:query]
     operation_name = params[:operationName]
     context = {
-      session: session,
-      user: User.find_by(id: session[:user_id])
+      session: session
     }
     result = MiyataniElTrainingSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
+  rescue AuthorizationError
+    render json: { error: { message: 'Authorization Error' } }, status: :forbidden
   rescue AdminAuthorizationError
     render json: { error: { message: 'Admin Authorization Error' } }, status: :forbidden
   rescue => e

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,5 +1,6 @@
 class GraphqlController < ApplicationController
   class AuthorizationError < StandardError; end
+
   class AdminAuthorizationError < StandardError; end
 
   def execute

--- a/app/graphql/mutations/admin_create_user.rb
+++ b/app/graphql/mutations/admin_create_user.rb
@@ -8,14 +8,10 @@ module Mutations
     argument :role_id,               ID,     required: true
 
     def resolve(**args)
-      user = context[:user]
-      unless user.role.id == Role::ADMIN
-        raise GraphqlController::AdminAuthorizationError
-      end
-
-      target_user = User.create!(args)
+      authenticate_admin!
+      user = User.create!(args)
       {
-        user: target_user
+        user: user
       }
     end
   end

--- a/app/graphql/mutations/admin_delete_user.rb
+++ b/app/graphql/mutations/admin_delete_user.rb
@@ -5,15 +5,12 @@ module Mutations
     argument :id, ID, required: true
 
     def resolve(id:)
-      user = context[:user]
-      unless user.role.id == Role::ADMIN
-        raise GraphqlController::AdminAuthorizationError
-      end
+      authenticate_admin!
 
       target_user = User.find(id)
       target_user.destroy!
-      if id == user.id
-        context[:session][:user_id] = nil # 自分ならアカウント削除後サインアウト
+      if id == current_user.id
+        sign_out # 自分ならアカウント削除後サインアウト
       end
       {
         user: target_user

--- a/app/graphql/mutations/admin_update_user.rb
+++ b/app/graphql/mutations/admin_update_user.rb
@@ -10,15 +10,12 @@ module Mutations
     argument :role_id,               ID,     required: false
 
     def resolve(id:, **args)
-      user = context[:user]
-      unless user.role.id == Role::ADMIN
-        raise GraphqlController::AdminAuthorizationError
-      end
+      authenticate_admin!
 
-      target_user = User.find(id)
-      target_user.update!(args)
+      user = User.find(id)
+      user.update!(args)
       {
-        user: target_user
+        user: user
       }
     end
   end

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -1,5 +1,6 @@
 module Mutations
   class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    include GraphqlHelper
     argument_class Types::BaseArgument
     field_class Types::BaseField
     input_object_class Types::BaseInputObject

--- a/app/graphql/mutations/create_label.rb
+++ b/app/graphql/mutations/create_label.rb
@@ -1,0 +1,15 @@
+module Mutations
+  class CreateLabel < BaseMutation
+    field :label, Types::LabelType, null: true
+
+    argument :name, String, required: true
+
+    def resolve(name:)
+      user = context[:user]
+      return if user.nil?
+
+      label = user.labels.create(name: name)
+      { label: label }
+    end
+  end
+end

--- a/app/graphql/mutations/create_label.rb
+++ b/app/graphql/mutations/create_label.rb
@@ -1,6 +1,6 @@
 module Mutations
   class CreateLabel < BaseMutation
-    field :label, Types::LabelType, null: true
+    field :labels, [Types::LabelType], null: true
 
     argument :name, String, required: true
 
@@ -8,8 +8,8 @@ module Mutations
       user = context[:user]
       return if user.nil?
 
-      label = user.labels.create(name: name)
-      { label: label }
+      user.labels.create(name: name)
+      { labels: user.labels.order(name: 'ASC') }
     end
   end
 end

--- a/app/graphql/mutations/create_label.rb
+++ b/app/graphql/mutations/create_label.rb
@@ -5,11 +5,10 @@ module Mutations
     argument :name, String, required: true
 
     def resolve(name:)
-      user = context[:user]
-      return if user.nil?
+      authenticate_user!
 
-      user.labels.create(name: name)
-      { labels: user.labels.order(name: 'ASC') }
+      current_user.labels.create(name: name)
+      { labels: current_user.labels.order(name: 'ASC') }
     end
   end
 end

--- a/app/graphql/mutations/create_task.rb
+++ b/app/graphql/mutations/create_task.rb
@@ -10,10 +10,9 @@ module Mutations
     argument :label_ids,       [ID],   required: false
 
     def resolve(label_ids: [], **args)
-      user = context[:user]
-      return if user.nil?
+      authenticate_user!
 
-      task = Task.create!(args.merge(user_id: user['id']))
+      task = Task.create!(args.merge(user_id: current_user.id))
       task.reset_labels(label_ids)
       {
         task: task

--- a/app/graphql/mutations/create_task.rb
+++ b/app/graphql/mutations/create_task.rb
@@ -7,14 +7,14 @@ module Mutations
     argument :deadline,        String, required: false
     argument :done_id,         ID,     required: false
     argument :priority_number, Int,    required: false
+    argument :label_ids,       [ID],   required: false
 
-    def resolve(**args)
+    def resolve(label_ids: [], **args)
       user = context[:user]
       return if user.nil?
 
-      task = Task.create!(
-        args.merge(user_id: user['id'])
-      )
+      task = Task.create!(args.merge(user_id: user['id']))
+      task.reset_labels(label_ids)
       {
         task: task
       }

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -8,7 +8,7 @@ module Mutations
 
     def resolve(**args)
       user = User.create!(args)
-      context[:session][:user_id] = user.id
+      sign_in(user)
       {
         user: user
       }

--- a/app/graphql/mutations/delete_label.rb
+++ b/app/graphql/mutations/delete_label.rb
@@ -1,0 +1,16 @@
+module Mutations
+  class DeleteLabel < BaseMutation
+    field :label, Types::LabelType, null: true
+
+    argument :id,   ID,     required: true
+
+    def resolve(id:)
+      user = context[:user]
+      return if user.nil?
+
+      label = user.labels.find(id)
+      label.destroy!
+      { label: label }
+    end
+  end
+end

--- a/app/graphql/mutations/delete_label.rb
+++ b/app/graphql/mutations/delete_label.rb
@@ -1,6 +1,6 @@
 module Mutations
   class DeleteLabel < BaseMutation
-    field :label, Types::LabelType, null: true
+    field :labels, [Types::LabelType], null: true
 
     argument :id, ID, required: true
 
@@ -10,7 +10,7 @@ module Mutations
 
       label = user.labels.find(id)
       label.destroy!
-      { label: label }
+      { labels: user.labels.order(name: 'ASC') }
     end
   end
 end

--- a/app/graphql/mutations/delete_label.rb
+++ b/app/graphql/mutations/delete_label.rb
@@ -5,12 +5,11 @@ module Mutations
     argument :id, ID, required: true
 
     def resolve(id:)
-      user = context[:user]
-      return if user.nil?
+      authenticate_user!
 
-      label = user.labels.find(id)
+      label = current_user.labels.find(id)
       label.destroy!
-      { labels: user.labels.order(name: 'ASC') }
+      { labels: current_user.labels.order(name: 'ASC') }
     end
   end
 end

--- a/app/graphql/mutations/delete_label.rb
+++ b/app/graphql/mutations/delete_label.rb
@@ -2,7 +2,7 @@ module Mutations
   class DeleteLabel < BaseMutation
     field :label, Types::LabelType, null: true
 
-    argument :id,   ID,     required: true
+    argument :id, ID, required: true
 
     def resolve(id:)
       user = context[:user]

--- a/app/graphql/mutations/delete_task.rb
+++ b/app/graphql/mutations/delete_task.rb
@@ -5,10 +5,9 @@ module Mutations
     argument :id, ID, required: true
 
     def resolve(id: nil)
-      user = context[:user]
-      return if user.nil?
+      authenticate_user!
 
-      task = Task.where(user_id: user['id']).find(id)
+      task = current_user.tasks.find(id)
       task.destroy!
       {
         task: task

--- a/app/graphql/mutations/delete_user.rb
+++ b/app/graphql/mutations/delete_user.rb
@@ -3,9 +3,8 @@ module Mutations
     field :user, Types::UserType, null: true
 
     def resolve
-      user = context[:user]
-      user.destroy!
-      context[:session][:user_id] = nil
+      current_user.destroy!
+      sign_out
       {
         user: nil
       }

--- a/app/graphql/mutations/set_label.rb
+++ b/app/graphql/mutations/set_label.rb
@@ -1,0 +1,27 @@
+module Mutations
+  class SetLabel < BaseMutation
+    # タスクにラベルを設定・解除するMutation
+    field :task_label, Types::TaskLabelType, null: false
+
+    argument :task_id,  ID,      required: true
+    argument :label_id, ID,      required: true
+    argument :checked,  Boolean, required: true
+
+    def resolve(task_id:, label_id:, checked:)
+      user = context[:user]
+      return if user.nil?
+
+      # タスク・食べるがログイン中のユーザーのものか確認
+      user.tasks.find(task_id)
+      user.labels.find(label_id)
+
+      if checked
+        task_label = TaskLabel.create!(task_id: task_id, label_id: label_id)
+      else
+        task_label = TaskLabel.find_by(task_id: task_id, label_id: label_id)
+        task_label.destroy!
+      end
+      { task_label: task_label }
+    end
+  end
+end

--- a/app/graphql/mutations/set_label.rb
+++ b/app/graphql/mutations/set_label.rb
@@ -8,12 +8,11 @@ module Mutations
     argument :checked,  Boolean, required: true
 
     def resolve(task_id:, label_id:, checked:)
-      user = context[:user]
-      return if user.nil?
+      authenticate_user!
 
       # タスク・食べるがログイン中のユーザーのものか確認
-      user.tasks.find(task_id)
-      user.labels.find(label_id)
+      current_user.tasks.find(task_id)
+      current_user.labels.find(label_id)
 
       if checked
         task_label = TaskLabel.create!(task_id: task_id, label_id: label_id)

--- a/app/graphql/mutations/sign_in.rb
+++ b/app/graphql/mutations/sign_in.rb
@@ -7,7 +7,7 @@ module Mutations
 
     def resolve(name:, password:)
       user = User.search(name, password)
-      context[:session][:user_id] = user.id
+      sign_in(user)
       {
         user: user
       }

--- a/app/graphql/mutations/sign_out.rb
+++ b/app/graphql/mutations/sign_out.rb
@@ -3,7 +3,7 @@ module Mutations
     field :user, Types::UserType, null: true
 
     def resolve
-      context[:session][:user_id] = nil
+      sign_out
       {
         user: nil
       }

--- a/app/graphql/mutations/update_label.rb
+++ b/app/graphql/mutations/update_label.rb
@@ -1,0 +1,17 @@
+module Mutations
+  class UpdateLabel < BaseMutation
+    field :label, Types::LabelType, null: true
+
+    argument :id,   ID,     required: true
+    argument :name, String, required: true
+
+    def resolve(id:, name:)
+      user = context[:user]
+      return if user.nil?
+
+      label = user.labels.find(id)
+      label.update!(name: name)
+      { label: label }
+    end
+  end
+end

--- a/app/graphql/mutations/update_label.rb
+++ b/app/graphql/mutations/update_label.rb
@@ -6,12 +6,11 @@ module Mutations
     argument :name, String, required: true
 
     def resolve(id:, name:)
-      user = context[:user]
-      return if user.nil?
+      authenticate_user!
 
-      label = user.labels.find(id)
+      label = current_user.labels.find(id)
       label.update!(name: name)
-      { labels: user.labels.order(name: 'ASC') }
+      { labels: current_user.labels.order(name: 'ASC') }
     end
   end
 end

--- a/app/graphql/mutations/update_label.rb
+++ b/app/graphql/mutations/update_label.rb
@@ -1,6 +1,6 @@
 module Mutations
   class UpdateLabel < BaseMutation
-    field :label, Types::LabelType, null: true
+    field :labels, [Types::LabelType], null: true
 
     argument :id,   ID,     required: true
     argument :name, String, required: true
@@ -11,7 +11,7 @@ module Mutations
 
       label = user.labels.find(id)
       label.update!(name: name)
-      { label: label }
+      { labels: user.labels.order(name: 'ASC') }
     end
   end
 end

--- a/app/graphql/mutations/update_task.rb
+++ b/app/graphql/mutations/update_task.rb
@@ -8,15 +8,15 @@ module Mutations
     argument :deadline,        String, required: false
     argument :done_id,         ID,     required: false
     argument :priority_number, Int,    required: false
+    argument :label_ids,       [ID],   required: false
 
-    def resolve(**args)
+    def resolve(id:, label_ids: [], **args)
       user = context[:user]
       return if user.nil?
 
-      task = Task.where(user_id: user['id']).find(args[:id])
-      task.update!(
-        args.except(:id)
-      )
+      task = Task.where(user_id: user.id).find(id)
+      task.update!(args)
+      task.reset_labels(label_ids)
       {
         task: task
       }

--- a/app/graphql/mutations/update_task.rb
+++ b/app/graphql/mutations/update_task.rb
@@ -11,10 +11,9 @@ module Mutations
     argument :label_ids,       [ID],   required: false
 
     def resolve(id:, label_ids: [], **args)
-      user = context[:user]
-      return if user.nil?
+      authenticate_user!
 
-      task = Task.where(user_id: user.id).find(id)
+      task = Task.where(user_id: current_user.id).find(id)
       task.update!(args)
       task.reset_labels(label_ids)
       {

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -1,0 +1,5 @@
+module Resolvers
+  class BaseResolver < GraphQL::Schema::Resolver
+    include GraphqlHelper
+  end
+end

--- a/app/graphql/resolvers/labels.rb
+++ b/app/graphql/resolvers/labels.rb
@@ -1,0 +1,10 @@
+module Resolvers
+  class Labels < GraphQL::Schema::Resolver
+    type [Types::LabelType], null: false
+
+    def resolve
+      user = context[:user]
+      Label.where(user_id: user.id).order(name: 'ASC')
+    end
+  end
+end

--- a/app/graphql/resolvers/labels.rb
+++ b/app/graphql/resolvers/labels.rb
@@ -1,18 +1,11 @@
 module Resolvers
-  class Labels < GraphQL::Schema::Resolver
+  class Labels < BaseResolver
     type [Types::LabelType], null: false
 
-    argument :user_id,   ID,      required: false
+    argument :user_id,   ID, required: false
 
     def resolve(user_id: nil)
-      user = context[:user]
-      if user_id.present? && user.role.id != Role::ADMIN
-        raise GraphQL::ExecutionError, 'admin only'
-      end
-
-      target_user_id = user_id || user.id
-
-      Label.where(user_id: target_user_id).order(name: 'ASC')
+      Label.where(user_id: target_user_id!(user_id)).order(name: 'ASC')
     end
   end
 end

--- a/app/graphql/resolvers/labels.rb
+++ b/app/graphql/resolvers/labels.rb
@@ -2,9 +2,17 @@ module Resolvers
   class Labels < GraphQL::Schema::Resolver
     type [Types::LabelType], null: false
 
-    def resolve
+    argument :user_id,   ID,      required: false
+
+    def resolve(user_id: nil)
       user = context[:user]
-      Label.where(user_id: user.id).order(name: 'ASC')
+      if user_id.present? && user.role.id != Role::ADMIN
+        raise GraphQL::ExecutionError, 'admin only'
+      end
+
+      target_user_id = user_id || user.id
+
+      Label.where(user_id: target_user_id).order(name: 'ASC')
     end
   end
 end

--- a/app/graphql/resolvers/tasks.rb
+++ b/app/graphql/resolvers/tasks.rb
@@ -11,6 +11,7 @@ module Resolvers
     argument :target,    String,  required: false
     argument :page,      Int,     required: false
     argument :user_id,   ID,      required: false
+    argument :label_id,  ID,      required: false
 
     def resolve(user_id: nil, **args)
       user = context[:user]
@@ -38,7 +39,8 @@ module Resolvers
         target: args.fetch(:target, 'all'),
         done_ids: args.fetch(:done_ids, [-1, 0, 1]),
         sort_type: args.fetch(:sort_type, 'created_at'),
-        is_asc: args.fetch(:is_asc, false)
+        is_asc: args.fetch(:is_asc, false),
+        label_id: args.fetch(:label_id, nil)
       }
     end
   end

--- a/app/graphql/resolvers/tasks.rb
+++ b/app/graphql/resolvers/tasks.rb
@@ -1,5 +1,5 @@
 module Resolvers
-  class Tasks < GraphQL::Schema::Resolver
+  class Tasks < BaseResolver
     PER_PAGE = 10
 
     type Types::TasksType, null: true
@@ -14,33 +14,13 @@ module Resolvers
     argument :label_id,  ID,      required: false
 
     def resolve(user_id: nil, **args)
-      user = context[:user]
-      if user_id.present? && user.role.id != Role::ADMIN
-        raise GraphqlController::AdminAuthorizationError
-      end
-
-      target_user_id = user_id || user.id # ユーザーを指定していなければログイン中のユーザーのデータを取得
+      tasks = Task.search(target_user_id!(user_id), args)
       page = args.fetch(:page, 1)
-
-      tasks = Task.where(user_id: target_user_id).search(**search_params(args))
       count = tasks.count
       {
         tasks: tasks.page(page).per(PER_PAGE),
         count: count,
         max_page: (count / 10.0).ceil
-      }
-    end
-
-    private
-
-    def search_params(args)
-      {
-        word: args.fetch(:word, ''),
-        target: args.fetch(:target, 'all'),
-        done_ids: args.fetch(:done_ids, [-1, 0, 1]),
-        sort_type: args.fetch(:sort_type, 'created_at'),
-        is_asc: args.fetch(:is_asc, false),
-        label_id: args.fetch(:label_id, nil)
       }
     end
   end

--- a/app/graphql/resolvers/user_signed_in.rb
+++ b/app/graphql/resolvers/user_signed_in.rb
@@ -1,9 +1,9 @@
 module Resolvers
-  class UserSignedIn < GraphQL::Schema::Resolver
+  class UserSignedIn < BaseResolver
     type Types::UserType, null: true
 
     def resolve
-      context[:user]
+      current_user
     end
   end
 end

--- a/app/graphql/resolvers/users.rb
+++ b/app/graphql/resolvers/users.rb
@@ -1,13 +1,9 @@
 module Resolvers
-  class Users < GraphQL::Schema::Resolver
+  class Users < BaseResolver
     type [Types::UserType], null: false
 
     def resolve
-      user = context[:user]
-      unless user.role.id == Role::ADMIN
-        raise GraphqlController::AdminAuthorizationError
-      end
-
+      authenticate_admin!
       User.includes(:tasks).order(created_at: 'DESC')
     end
   end

--- a/app/graphql/types/label_type.rb
+++ b/app/graphql/types/label_type.rb
@@ -1,0 +1,15 @@
+module Types
+  class LabelType < Types::BaseObject
+    field :id, ID, null: false
+    field :name, String, null: false
+    field :user_id, Integer, null: false
+    field :user, UserType, null: false
+    field :tasks, [TaskType], null: false
+    field :tasks_count, Int, null: false
+    def tasks_count
+      object.tasks.size
+    end
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,9 @@
 module Types
   class MutationType < Types::BaseObject
+    field :set_label, mutation: Mutations::SetLabel
+    field :delete_label, mutation: Mutations::DeleteLabel
+    field :update_label, mutation: Mutations::UpdateLabel
+    field :create_label, mutation: Mutations::CreateLabel
     field :admin_delete_user, mutation: Mutations::AdminDeleteUser
     field :admin_update_user, mutation: Mutations::AdminUpdateUser
     field :admin_create_user, mutation: Mutations::AdminCreateUser

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,6 +1,6 @@
 module Types
   class QueryType < Types::BaseObject
-    # Add `node(id: ID!) and `nodes(ids: [ID!]!)`
+    include GraphqlHelper
     include GraphQL::Types::Relay::HasNodeField
     include GraphQL::Types::Relay::HasNodesField
 
@@ -16,11 +16,7 @@ module Types
       argument :id, ID, required: true
     end
     def user(id:)
-      user = context[:user]
-      unless user.role.id == Role::ADMIN
-        raise GraphqlController::AdminAuthorizationError
-      end
-
+      authenticate_admin!
       User.find(id)
     end
     field :users, resolver: Resolvers::Users
@@ -30,7 +26,6 @@ module Types
       argument :id, ID, required: true
     end
     def label(id:)
-      # TODO: アクセス制御
       Label.find(id)
     end
     field :labels, resolver: Resolvers::Labels

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -25,5 +25,14 @@ module Types
     end
     field :users, resolver: Resolvers::Users
     field :user_signed_in, resolver: Resolvers::UserSignedIn
+
+    field :label, LabelType, null: true do
+      argument :id, ID, required: true
+    end
+    def label(id:)
+      # TODO: アクセス制御
+      Label.find(id)
+    end
+    field :labels, resolver: Resolvers::Labels
   end
 end

--- a/app/graphql/types/task_label_type.rb
+++ b/app/graphql/types/task_label_type.rb
@@ -1,0 +1,11 @@
+module Types
+  class TaskLabelType < Types::BaseObject
+    field :id, ID, null: false
+    field :task_id, Integer, null: false
+    field :task, Types::TaskType, null: false
+    field :label_id, Integer, null: false
+    field :label, Types::LabelType, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/graphql/types/task_type.rb
+++ b/app/graphql/types/task_type.rb
@@ -6,6 +6,7 @@ module Types
     field :done, DoneType, null: false
     field :done_id, ID, null: false
     field :priority_number, Int, null: false
+    field :labels, [Types::LabelType], null: false
     field :deadline, GraphQL::Types::ISO8601DateTime, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -11,5 +11,6 @@ module Types
     def tasks_count
       object.tasks.size
     end
+    field :labels, [Types::LabelType], null: false
   end
 end

--- a/app/helpers/graphql_helper.rb
+++ b/app/helpers/graphql_helper.rb
@@ -1,0 +1,36 @@
+module GraphqlHelper
+  def authenticate_user!
+    return if current_user.present?
+
+    raise GraphqlController::AdminAuthorizationError
+  end
+
+  def authenticate_admin!
+    authenticate_user!
+    return if current_user.role.id == Role::ADMIN
+
+    raise GraphqlController::AuthorizationError
+  end
+
+  def target_user_id!(user_id)
+    if user_id.present?
+      authenticate_admin!
+      user_id
+    else
+      authenticate_user!
+      current_user.id
+    end
+  end
+
+  def current_user
+    User.find_by(id: context[:session][:user_id])
+  end
+
+  def sign_in(user)
+    context[:session][:user_id] = user.id
+  end
+
+  def sign_out
+    context[:session][:user_id] = nil
+  end
+end

--- a/app/helpers/graphql_helper.rb
+++ b/app/helpers/graphql_helper.rb
@@ -2,14 +2,14 @@ module GraphqlHelper
   def authenticate_user!
     return if current_user.present?
 
-    raise GraphqlController::AdminAuthorizationError
+    raise Application::AuthorizationError
   end
 
   def authenticate_admin!
     authenticate_user!
     return if current_user.role.id == Role::ADMIN
 
-    raise GraphqlController::AuthorizationError
+    raise Application::AdminAuthorizationError
   end
 
   def target_user_id!(user_id)

--- a/app/javascript/components/common/DoneForm.tsx
+++ b/app/javascript/components/common/DoneForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { UseFormSetValue } from 'react-hook-form';
 import { Inputs } from 'common/TaskForm';
 import Box from '@mui/material/Box';
@@ -15,6 +15,10 @@ interface DoneFormProps {
 
 const DoneForm = (props: DoneFormProps) => {
   const [done, setDone] = useState(props.defaultValue);
+
+  useEffect(() => {
+    props.setValue('doneId', props.defaultValue);
+  }, []);
 
   const handleChange = (event) => {
     setDone(event.target.value);

--- a/app/javascript/components/common/HeaderMenu.tsx
+++ b/app/javascript/components/common/HeaderMenu.tsx
@@ -125,14 +125,16 @@ const HeaderMenu = () => {
           </ListItemIcon>
           アカウント削除
         </MenuItem>
-        <Divider />
         {user?.role.text == 'admin' && (
-          <MenuItem component={Link} to="/admin">
-            <ListItemIcon>
-              <AdminPanelSettingsIcon fontSize="small" />
-            </ListItemIcon>
-            管理ページ
-          </MenuItem>
+          <div>
+            <Divider />
+            <MenuItem component={Link} to="/admin">
+              <ListItemIcon>
+                <AdminPanelSettingsIcon fontSize="small" />
+              </ListItemIcon>
+              管理ページ
+            </MenuItem>
+          </div>
         )}
       </Menu>
     </>

--- a/app/javascript/components/common/LabelForm.tsx
+++ b/app/javascript/components/common/LabelForm.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useContext } from 'react';
 import { UtilContext } from 'utils/contexts';
 import { UseFormSetValue } from 'react-hook-form';
+import { Link } from 'react-router-dom';
+import MuiLink from '@mui/material/Link';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -30,6 +32,7 @@ interface LabelFormProps {
   setValue?: UseFormSetValue<{ labelIds: Label['id'][] }>;
   onChange?: (labels: Label[]) => void;
   canEdit?: boolean;
+  userId?: string;
 }
 
 const LabelForm = (props: LabelFormProps) => {
@@ -37,6 +40,8 @@ const LabelForm = (props: LabelFormProps) => {
   const [open, setOpen] = useState(false);
 
   const canEdit = props.canEdit !== false; // default: true
+  const baseUrl = props.userId ? `/admin/users/${props.userId}/tasks` : '/';
+
   // ---------------------------------------------------------
 
   const [labelIds, setLabelIds] = useState(props.defaultValue);
@@ -44,7 +49,6 @@ const LabelForm = (props: LabelFormProps) => {
 
   useEffect(() => {
     props.setValue?.('labelIds', labelIds);
-    console.log(props.labels, labelIds);
   }, []);
 
   const handleOpen = () => {
@@ -134,13 +138,16 @@ const LabelForm = (props: LabelFormProps) => {
       ：
       {labelIds.map((labelId) => {
         const label = props.labels.find((label) => label.id == labelId);
+        if (!label) return <></>;
         return (
-          <span
+          <MuiLink
             key={label.id}
             style={{ textDecoration: 'underline', margin: '0 10px' }}
+            component={Link}
+            to={`${baseUrl}?labelId=${label.id}`}
           >
             {label.name}
-          </span>
+          </MuiLink>
         );
       })}
       <Dialog fullWidth maxWidth={'xs'} open={open}>

--- a/app/javascript/components/common/LabelForm.tsx
+++ b/app/javascript/components/common/LabelForm.tsx
@@ -1,0 +1,174 @@
+import React, { useState, useEffect } from 'react';
+import { UseFormSetValue } from 'react-hook-form';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import Dialog from '@mui/material/Dialog';
+import RadioGroup from '@mui/material/RadioGroup';
+import Radio from '@mui/material/Radio';
+import FormControlLabel from '@mui/material/FormControlLabel';
+
+const options = [
+  'None',
+  'Atria',
+  'Callisto',
+  'Dione',
+  'Ganymede',
+  'Hangouts Call',
+  'Luna',
+  'Oberon',
+  'Phobos',
+  'Pyxis',
+  'Sedna',
+  'Titania',
+  'Triton',
+  'Umbriel',
+];
+
+export interface ConfirmationDialogRawProps {
+  id: string;
+  keepMounted: boolean;
+  value: string;
+  open: boolean;
+  onClose: (value?: string) => void;
+}
+
+function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
+  const { onClose, value: valueProp, open, ...other } = props;
+  const [value, setValue] = React.useState(valueProp);
+  const radioGroupRef = React.useRef<HTMLElement>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      setValue(valueProp);
+    }
+  }, [valueProp, open]);
+
+  const handleEntering = () => {
+    if (radioGroupRef.current != null) {
+      radioGroupRef.current.focus();
+    }
+  };
+
+  const handleCancel = () => {
+    onClose();
+  };
+
+  const handleOk = () => {
+    onClose(value);
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setValue((event.target as HTMLInputElement).value);
+  };
+
+  return (
+    <Dialog
+      sx={{ '& .MuiDialog-paper': { width: '80%', maxHeight: 435 } }}
+      maxWidth="xs"
+      TransitionProps={{ onEntering: handleEntering }}
+      open={open}
+      {...other}
+    >
+      <DialogTitle>Phone Ringtone</DialogTitle>
+      <DialogContent dividers>
+        <RadioGroup
+          ref={radioGroupRef}
+          aria-label="ringtone"
+          name="ringtone"
+          value={value}
+          onChange={handleChange}
+        >
+          {options.map((option) => (
+            <FormControlLabel
+              value={option}
+              key={option}
+              control={<Radio />}
+              label={option}
+            />
+          ))}
+        </RadioGroup>
+      </DialogContent>
+      <DialogActions>
+        <Button autoFocus onClick={handleCancel}>
+          Cancel
+        </Button>
+        <Button onClick={handleOk}>Ok</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+interface LabelFormProps {
+  defaultValue: string[];
+  setValue: UseFormSetValue<{ labelIds: string[] }>;
+}
+
+const LabelForm = (props: LabelFormProps) => {
+  // const [labelIds, setLabelIds] = useState(props.defaultValue);
+
+  // useEffect(() => {
+  //   props.setValue('labelIds', labelIds);
+  // }, []);
+
+  // const handleChange = (event) => {
+  //   const val = event.target.value;
+  //   setLabelIds(val);
+  //   props.setValue('labelIds', val);
+  // };
+
+  const [open, setOpen] = React.useState(false);
+  const [value, setValue] = React.useState('Dione');
+
+  const handleClickListItem = () => {
+    setOpen(true);
+  };
+
+  const handleClose = (newValue?: string) => {
+    setOpen(false);
+
+    if (newValue) {
+      setValue(newValue);
+    }
+  };
+
+  return (
+    <Box sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}>
+      <List component="div" role="group">
+        <ListItem button divider disabled>
+          <ListItemText primary="Interruptions" />
+        </ListItem>
+        <ListItem
+          button
+          divider
+          aria-haspopup="true"
+          aria-controls="ringtone-menu"
+          aria-label="phone ringtone"
+          onClick={handleClickListItem}
+        >
+          <ListItemText primary="Phone ringtone" secondary={value} />
+        </ListItem>
+        <ListItem button divider disabled>
+          <ListItemText
+            primary="Default notification ringtone"
+            secondary="Tethys"
+          />
+        </ListItem>
+        <ConfirmationDialogRaw
+          id="ringtone-menu"
+          keepMounted
+          open={open}
+          onClose={handleClose}
+          value={value}
+        />
+      </List>
+    </Box>
+  );
+};
+
+export default LabelForm;

--- a/app/javascript/components/common/LabelForm.tsx
+++ b/app/javascript/components/common/LabelForm.tsx
@@ -163,7 +163,7 @@ const LabelForm = (props: LabelFormProps) => {
         </DialogTitle>
         <DialogContent sx={{ textAlign: 'center' }}>
           {props.labels.map((label) => (
-            <div key={label.id}>
+            <div key={label.id} data-test-label={label.id}>
               <div
                 style={{
                   display: 'flex',

--- a/app/javascript/components/common/LabelForm.tsx
+++ b/app/javascript/components/common/LabelForm.tsx
@@ -26,21 +26,24 @@ import { Label } from 'utils/types';
 interface LabelFormProps {
   labels: Label[];
   defaultValue: Label['id'][];
-  setValue: UseFormSetValue<{ labelIds: Label['id'][] }>;
   setLabels: (labels: Label[]) => void;
+  setValue?: UseFormSetValue<{ labelIds: Label['id'][] }>;
+  onChange?: (labels: Label[]) => void;
+  canEdit?: boolean;
 }
 
 const LabelForm = (props: LabelFormProps) => {
   const { util } = useContext(UtilContext);
   const [open, setOpen] = useState(false);
 
+  const canEdit = props.canEdit !== false; // default: true
   // ---------------------------------------------------------
 
   const [labelIds, setLabelIds] = useState(props.defaultValue);
   const [newLabelIds, setNewLabelIds] = useState([]);
 
   useEffect(() => {
-    props.setValue('labelIds', labelIds);
+    props.setValue?.('labelIds', labelIds);
     console.log(props.labels, labelIds);
   }, []);
 
@@ -55,7 +58,8 @@ const LabelForm = (props: LabelFormProps) => {
   };
 
   const handleSetLabel = () => {
-    props.setValue('labelIds', newLabelIds);
+    props.setValue?.('labelIds', newLabelIds);
+    props.onChange?.(newLabelIds);
     setLabelIds(newLabelIds);
     setNewLabelIds([]);
     setOpen(false);
@@ -122,9 +126,11 @@ const LabelForm = (props: LabelFormProps) => {
   return (
     <>
       ラベル
-      <IconButton size="small" onClick={handleOpen}>
-        <EditIcon />
-      </IconButton>
+      {canEdit && (
+        <IconButton size="small" onClick={handleOpen}>
+          <EditIcon />
+        </IconButton>
+      )}
       ：
       {labelIds.map((labelId) => {
         const label = props.labels.find((label) => label.id == labelId);

--- a/app/javascript/components/common/LabelForm.tsx
+++ b/app/javascript/components/common/LabelForm.tsx
@@ -90,8 +90,11 @@ const LabelForm = (props: LabelFormProps) => {
       util.flashMessage('同じラベルが既に存在します', 'error');
     },
   });
-  const handleCreateLabel = () => {
-    const name = window.prompt('ラベル名を入力してください');
+  const handleCreateLabel = async () => {
+    setOpen(false);
+    const name = await util.promptDialog('ラベル名を入力してください');
+    setOpen(true);
+    if (!name) return;
     createLabel({ variables: { name } });
   };
 
@@ -105,9 +108,15 @@ const LabelForm = (props: LabelFormProps) => {
       util.flashMessage('同じラベルが既に存在します', 'error');
     },
   });
-  const handleUpdateLabel = (label) => () => {
-    const name = window.prompt('ラベル名を入力してください', label.name);
-    if (name !== label.name) updateLabel({ variables: { id: label.id, name } });
+  const handleUpdateLabel = (label) => async () => {
+    setOpen(false);
+    const name = await util.promptDialog(
+      'ラベル名を入力してください',
+      label.name
+    );
+    setOpen(true);
+    if (!name || name == label.name) return;
+    updateLabel({ variables: { id: label.id, name } });
   };
 
   // ラベルの削除 ----------------------------------------------

--- a/app/javascript/components/common/LabelLinks.tsx
+++ b/app/javascript/components/common/LabelLinks.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import MuiLink from '@mui/material/Link';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+
+import { Label } from 'utils/types';
+
+interface LabelLinksProps {
+  labels: Label[];
+  userId?: string;
+}
+
+const LabelLinks = (props: LabelLinksProps) => {
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const baseUrl = props.userId ? `/admin/users/${props.userId}/tasks` : '/';
+
+  return (
+    <>
+      <MuiLink
+        component="span"
+        sx={{ position: 'absolute', bottom: '5px', right: '15px' }}
+        onClick={handleOpen}
+        data-test-label-list="#"
+      >
+        ラベル一覧
+      </MuiLink>
+      <Dialog maxWidth={'xs'} open={open} onClose={handleClose}>
+        <DialogTitle sx={{ textAlign: 'center' }}>ラベル一覧</DialogTitle>
+        <DialogContent sx={{ textAlign: 'center' }}>
+          {props.labels.map((label) => (
+            <div
+              key={label.id}
+              style={{
+                textAlign: 'left',
+                margin: '15px 0',
+              }}
+            >
+              <MuiLink
+                component={Link}
+                to={`${baseUrl}?labelId=${label.id}`}
+                onClick={handleClose}
+              >
+                {label.name}({label.tasksCount})
+              </MuiLink>
+            </div>
+          ))}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>閉じる</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default LabelLinks;

--- a/app/javascript/components/common/PromptDialog.tsx
+++ b/app/javascript/components/common/PromptDialog.tsx
@@ -1,0 +1,99 @@
+import React, { forwardRef, useState, useImperativeHandle } from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Slide from '@mui/material/Slide';
+import { TransitionProps } from '@mui/material/transitions';
+import TextField from '@mui/material/TextField';
+
+const Transition = forwardRef(
+  (
+    props: TransitionProps & {
+      children: React.ReactElement<any, any>; // eslint-disable-line
+    },
+    ref: React.Ref<unknown>
+  ) => {
+    return <Slide direction="up" ref={ref} {...props} />;
+  }
+);
+Transition.displayName = 'Transition';
+
+export interface PromptDialogHandler {
+  prompt: (message: string, defaultValue?: string) => Promise<string>;
+}
+
+const PromptDialog = forwardRef<PromptDialogHandler>((props, ref) => {
+  const [open, setOpen] = useState(false);
+
+  const [handleAgree, setHandleAgree] = useState(null);
+  const [handleDisagree, setHandleDisagree] = useState(null);
+  const resetHandle = () => {
+    setHandleAgree(null);
+    setHandleDisagree(null);
+    setOpen(false);
+  };
+  const [message, setMessage] = useState('');
+  const [defaultValue, setDefaultValue] = useState('');
+  // const [resultValue, setValue] = useState('');
+  // const getResultValue = () => {
+  //   return resultValue;
+  // };
+  // const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  //   setValue(event.target.value);
+  //   console.log(resultValue, event.target.value);
+  // };
+  const [handleChange, setHandleChange] = useState(null);
+
+  useImperativeHandle(ref, () => ({
+    prompt: (message = '本当によろしいですか？', defaultValue = '') =>
+      new Promise((resolve) => {
+        let resultValue = '';
+        setHandleChange(() => (event: React.ChangeEvent<HTMLInputElement>) => {
+          resultValue = event.target.value;
+          setDefaultValue(resultValue);
+        });
+        setHandleAgree(() => () => {
+          resetHandle();
+          resolve(resultValue);
+        });
+        setHandleDisagree(() => () => {
+          resetHandle();
+          resolve('');
+        });
+        setMessage(message);
+        setDefaultValue(defaultValue);
+        setOpen(true);
+      }),
+  }));
+
+  return (
+    <div>
+      <Dialog
+        open={open}
+        TransitionComponent={Transition}
+        keepMounted
+        aria-describedby="alert-dialog-slide-description"
+      >
+        <DialogTitle>{message}</DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            id="prompt"
+            variant="outlined"
+            value={defaultValue}
+            onChange={handleChange}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleAgree}>決定</Button>
+          <Button onClick={handleDisagree}>キャンセル</Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+});
+PromptDialog.displayName = 'PromptDialog';
+
+export default PromptDialog;

--- a/app/javascript/components/common/SearchForm.tsx
+++ b/app/javascript/components/common/SearchForm.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useState } from 'react';
 import FormGroup from '@mui/material/FormGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Checkbox from '@mui/material/Checkbox';
@@ -10,26 +10,52 @@ import Paper from '@mui/material/Paper';
 import InputBase from '@mui/material/InputBase';
 import IconButton from '@mui/material/IconButton';
 import SearchIcon from '@mui/icons-material/Search';
-
+import { Button } from '@mui/material';
+import { Done } from 'utils/types';
 interface SearchFormProps {
   onSearch: ({ word, target, doneIds }) => void;
+  onReset: () => void;
+  word: string;
+  target: 'all' | 'title' | 'description';
+  doneIds: Done['id'][];
 }
 
 const SearchForm = (props: SearchFormProps) => {
-  const formRef = useRef();
+  const [formValues, setFormValues] = useState({
+    word: props.word,
+    target: props.target,
+    doneIds: props.doneIds,
+  });
+  const handleChangeWord = (event) => {
+    setFormValues({ ...formValues, word: event.target.value });
+  };
+  const handleChangeTarget = (event) => {
+    setFormValues({ ...formValues, target: event.target.value });
+  };
+  const handleChangeDoneIds = (event) => {
+    const ids = new Set(formValues.doneIds);
+    if (event.target.checked) {
+      ids.add(String(event.target.value) as Done['id']);
+    } else {
+      ids.delete(String(event.target.value) as Done['id']);
+    }
+    setFormValues({ ...formValues, doneIds: Array.from(ids) });
+  };
+  const handleReset = () => {
+    setFormValues({
+      word: '',
+      target: 'all',
+      doneIds: ['-1', '0', '1'],
+    });
+    props.onReset();
+  };
 
   const handleSubmit = () => {
-    const formData = new FormData(formRef.current);
-
-    props.onSearch({
-      word: formData.get('word'),
-      target: formData.get('target'),
-      doneIds: formData.getAll('done_ids[]'),
-    });
+    props.onSearch(formValues);
   };
 
   return (
-    <Paper component="form" ref={formRef} sx={{ p: '2px 4px' }}>
+    <Paper component="form" sx={{ p: '2px 4px' }}>
       <Paper sx={{ p: '2px 4px', display: 'flex', alignItems: 'center' }}>
         <InputBase
           name="word"
@@ -42,6 +68,8 @@ const SearchForm = (props: SearchFormProps) => {
             event.preventDefault();
             handleSubmit();
           }}
+          value={formValues.word}
+          onChange={handleChangeWord}
         />
         <IconButton
           id="search"
@@ -59,7 +87,8 @@ const SearchForm = (props: SearchFormProps) => {
           row
           aria-label="search-target"
           name="target"
-          defaultValue="all"
+          value={formValues.target}
+          onChange={handleChangeTarget}
         >
           <FormLabel
             component="legend"
@@ -90,6 +119,7 @@ const SearchForm = (props: SearchFormProps) => {
           <FormLabel
             component="legend"
             sx={{ display: 'flex', alignItems: 'center' }}
+            onChange={handleChangeDoneIds}
           >
             ステータス：
           </FormLabel>
@@ -98,8 +128,9 @@ const SearchForm = (props: SearchFormProps) => {
               <Checkbox
                 name="done_ids[]"
                 value="-1"
-                defaultChecked
+                checked={formValues.doneIds.includes('-1')}
                 size="small"
+                onChange={handleChangeDoneIds}
               />
             }
             label="未着手"
@@ -109,8 +140,9 @@ const SearchForm = (props: SearchFormProps) => {
               <Checkbox
                 name="done_ids[]"
                 value="0"
-                defaultChecked
+                checked={formValues.doneIds.includes('0')}
                 size="small"
+                onChange={handleChangeDoneIds}
               />
             }
             label="着手"
@@ -120,14 +152,24 @@ const SearchForm = (props: SearchFormProps) => {
               <Checkbox
                 name="done_ids[]"
                 value="1"
-                defaultChecked
+                checked={formValues.doneIds.includes('1')}
                 size="small"
+                onChange={handleChangeDoneIds}
               />
             }
             label="完了"
           />
         </FormGroup>
       </FormControl>
+      <Button
+        variant="outlined"
+        color="error"
+        size="small"
+        sx={{ float: 'right', marginRight: '10px' }}
+        onClick={handleReset}
+      >
+        リセット
+      </Button>
     </Paper>
   );
 };

--- a/app/javascript/components/common/SearchForm.tsx
+++ b/app/javascript/components/common/SearchForm.tsx
@@ -18,6 +18,7 @@ interface SearchFormProps {
   word: string;
   target: 'all' | 'title' | 'description';
   doneIds: Done['id'][];
+  children?: React.ReactNode;
 }
 
 const SearchForm = (props: SearchFormProps) => {
@@ -55,7 +56,7 @@ const SearchForm = (props: SearchFormProps) => {
   };
 
   return (
-    <Paper component="form" sx={{ p: '2px 4px' }}>
+    <Paper component="form" sx={{ p: '2px 4px', position: 'relative' }}>
       <Paper sx={{ p: '2px 4px', display: 'flex', alignItems: 'center' }}>
         <InputBase
           name="word"
@@ -114,6 +115,16 @@ const SearchForm = (props: SearchFormProps) => {
         </RadioGroup>
       </FormControl>
 
+      <Button
+        variant="outlined"
+        color="error"
+        size="small"
+        sx={{ float: 'right', margin: '10px 10px 0 0' }}
+        onClick={handleReset}
+      >
+        リセット
+      </Button>
+
       <FormControl component="fieldset">
         <FormGroup row aria-label="done_ids">
           <FormLabel
@@ -161,15 +172,8 @@ const SearchForm = (props: SearchFormProps) => {
           />
         </FormGroup>
       </FormControl>
-      <Button
-        variant="outlined"
-        color="error"
-        size="small"
-        sx={{ float: 'right', marginRight: '10px' }}
-        onClick={handleReset}
-      >
-        リセット
-      </Button>
+      <br />
+      {props.children}
     </Paper>
   );
 };

--- a/app/javascript/components/common/TaskForm.tsx
+++ b/app/javascript/components/common/TaskForm.tsx
@@ -47,12 +47,10 @@ const TaskForm = (props: TaskFormProps) => {
   };
 
   const { data } = useQueryEx(GQL_LABELS);
-  const [labels, setLabels] = useState([] as Label[]);
+  const [labels, setLabels] = useState(null as Label[]);
   useEffect(() => {
-    if (!data.labels) return;
-    setLabels(data.labels || []);
+    if (data.labels) setLabels(data.labels);
   }, [data]);
-  // console.log(props.task);
 
   return (
     <form>
@@ -71,7 +69,7 @@ const TaskForm = (props: TaskFormProps) => {
             />
           </FormItem>
           <FormItem>
-            {labels.length && (
+            {labels && (
               <LabelForm
                 setValue={setValue}
                 defaultValue={props.task.labels?.map((label) => label.id) || []}

--- a/app/javascript/components/common/TaskForm.tsx
+++ b/app/javascript/components/common/TaskForm.tsx
@@ -14,6 +14,7 @@ import { useForm } from 'react-hook-form';
 import Button from '@mui/material/Button';
 import { Grid } from '@mui/material';
 import { Task } from 'utils/types';
+import LabelForm from 'common/LabelForm';
 
 export type Inputs = {
   title: string;
@@ -57,6 +58,9 @@ const TaskForm = (props: TaskFormProps) => {
               error={!!errors.title}
               helperText={errors.title && 'タイトルを入力してください'}
             />
+          </FormItem>
+          <FormItem>
+            <LabelForm setValue={setValue} defaultValue={[]} />
           </FormItem>
           <FormItem>
             <TextField

--- a/app/javascript/components/common/TaskForm.tsx
+++ b/app/javascript/components/common/TaskForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';
@@ -15,6 +15,9 @@ import Button from '@mui/material/Button';
 import { Grid } from '@mui/material';
 import { Task } from 'utils/types';
 import LabelForm from 'common/LabelForm';
+import { GQL_LABELS } from 'utils/gql';
+import useQueryEx from 'hooks/useQueryEx';
+import { Label } from 'utils/types';
 
 export type Inputs = {
   title: string;
@@ -43,6 +46,14 @@ const TaskForm = (props: TaskFormProps) => {
     props.onAction(data);
   };
 
+  const { data } = useQueryEx(GQL_LABELS);
+  const [labels, setLabels] = useState([] as Label[]);
+  useEffect(() => {
+    if (!data.labels) return;
+    setLabels(data.labels || []);
+  }, [data]);
+  // console.log(props.task);
+
   return (
     <form>
       <TaskCard>
@@ -60,7 +71,14 @@ const TaskForm = (props: TaskFormProps) => {
             />
           </FormItem>
           <FormItem>
-            <LabelForm setValue={setValue} defaultValue={[]} />
+            {labels.length && (
+              <LabelForm
+                setValue={setValue}
+                defaultValue={props.task.labels?.map((label) => label.id) || []}
+                labels={labels}
+                setLabels={setLabels}
+              />
+            )}
           </FormItem>
           <FormItem>
             <TextField

--- a/app/javascript/components/common/TaskList.tsx
+++ b/app/javascript/components/common/TaskList.tsx
@@ -28,6 +28,7 @@ import {
 import { Label } from 'utils/types';
 import useQueryEx from 'hooks/useQueryEx';
 import useMutationEx from 'hooks/useMutationEx';
+import LabelLinks from './LabelLinks';
 
 const DEFAULT_SEARCH_PARAMETERS: {
   word: string;
@@ -142,7 +143,9 @@ const TaskList = (props: TaskListProps) => {
             word={searchParams.word}
             target={searchParams.target}
             doneIds={searchParams.doneIds}
-          />
+          >
+            <LabelLinks labels={labels} userId={props.userId} />
+          </SearchForm>
         </div>
         <div style={{ textAlign: 'right' }}>
           <SortForm

--- a/app/javascript/components/common/UtilProvider.tsx
+++ b/app/javascript/components/common/UtilProvider.tsx
@@ -2,12 +2,14 @@ import React, { useRef, useState } from 'react';
 import { UtilContext } from 'utils/contexts';
 import FlashMessage, { FlashMessageHandler } from 'common/FlashMessage';
 import ConfirmDialog, { ConfirmDialogHandler } from 'common/ConfirmDialog';
+import PromptDialog, { PromptDialogHandler } from 'common/PromptDialog';
 import Backdrop from '@mui/material/Backdrop';
 import CircularProgress from '@mui/material/CircularProgress';
 
 const UtilProvider = (props: { children: React.ReactNode }) => {
   const flashMessageRef = useRef({} as FlashMessageHandler);
   const confirmDialogRef = useRef({} as ConfirmDialogHandler);
+  const promptDialogRef = useRef({} as PromptDialogHandler);
   const [isLoading, setIsLoading] = useState(false);
 
   const util = {
@@ -15,6 +17,8 @@ const UtilProvider = (props: { children: React.ReactNode }) => {
       flashMessageRef.current.showMessage(message, severity),
     confirmDialog: async (message) =>
       await confirmDialogRef.current.confirm(message),
+    promptDialog: async (message, defaultValue = '') =>
+      await promptDialogRef.current.prompt(message, defaultValue),
     setBackdrop: (loading: boolean) => setIsLoading(loading),
   };
 
@@ -23,6 +27,7 @@ const UtilProvider = (props: { children: React.ReactNode }) => {
       {props.children}
       <FlashMessage ref={flashMessageRef} />
       <ConfirmDialog ref={confirmDialogRef} />
+      <PromptDialog ref={promptDialogRef} />
       <Backdrop
         sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}
         open={isLoading}

--- a/app/javascript/components/hooks/useMutationEx.tsx
+++ b/app/javascript/components/hooks/useMutationEx.tsx
@@ -14,8 +14,9 @@ const useMutationEx: useMutationEx = (mutation, options) => {
     if (options.onError) return;
     if (!error) return;
     console.error(error);
-    alert(
-      '申し訳ございません、エラーが発生しました。ページを再読み込みしてください。'
+    util.flashMessage(
+      '申し訳ございません、エラーが発生しました。ページを再読み込みしてください。',
+      'error'
     );
   }, [error]);
 

--- a/app/javascript/components/hooks/useQueryEx.tsx
+++ b/app/javascript/components/hooks/useQueryEx.tsx
@@ -13,8 +13,9 @@ const useQueryEx: useQueryEx = (query, options) => {
   useEffect(() => {
     if (!error) return;
     console.error(error);
-    alert(
-      '申し訳ございません、エラーが発生しました。ページを再読み込みしてください。'
+    util.flashMessage(
+      '申し訳ございません、エラーが発生しました。ページを再読み込みしてください。',
+      'error'
     );
   }, [error]);
 

--- a/app/javascript/components/page/AdminUserUpdate.tsx
+++ b/app/javascript/components/page/AdminUserUpdate.tsx
@@ -17,6 +17,12 @@ import useQueryEx from 'hooks/useQueryEx';
 import useMutationEx from 'hooks/useMutationEx';
 import { GQL_USER, GQL_ADMIN_UPDATE_USER } from 'utils/gql';
 
+type networkError = {
+  result: {
+    errors: { message: string }[];
+  };
+};
+
 const AdminUserUpdate = () => {
   const navigate = useNavigate();
   const params = useParams();
@@ -39,7 +45,7 @@ const AdminUserUpdate = () => {
       });
     },
     onError: (res) => {
-      const result = res.networkError.result;
+      const result = (res.networkError as unknown as networkError).result;
       const error_messages = result.errors.map((v) => v.message);
       if (error_messages.includes('Failed to save the record')) {
         setError('roleId', {

--- a/app/javascript/components/page/TaskPost.tsx
+++ b/app/javascript/components/page/TaskPost.tsx
@@ -2,35 +2,29 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import BaseLayout from 'BaseLayout';
 import TaskForm from 'common/TaskForm';
-import { client } from 'common/MyApolloProvider';
+import useMutationEx from 'hooks/useMutationEx';
 import { GQL_CREATE_TASK } from 'utils/gql';
+import { Task } from 'utils/types';
 
 const TaskPost = () => {
   const navigate = useNavigate();
 
+  const [createTask] = useMutationEx(GQL_CREATE_TASK, {
+    onCompleted: (res) => {
+      console.log(res);
+      navigate('/', { state: { message: 'タスクを投稿しました' } });
+    },
+  });
+
   const handleAdd = (data) => {
-    client
-      .mutate({
-        mutation: GQL_CREATE_TASK,
-        variables: {
-          title: data.title,
-          description: data.description,
-          deadline: data.deadline,
-          doneId: data.doneId,
-          priorityNumber: data.priorityNumber,
-        },
-      })
-      .then(({ data }) => {
-        console.log(data);
-        navigate('/', { state: { message: 'タスクを投稿しました' } });
-      });
+    createTask({ variables: data });
   };
 
   return (
     <BaseLayout>
       <TaskForm
         title="タスク投稿フォーム"
-        task={{}}
+        task={{} as Task}
         buttonText="投稿"
         onAction={handleAdd}
       />

--- a/app/javascript/components/utils/contexts.tsx
+++ b/app/javascript/components/utils/contexts.tsx
@@ -19,6 +19,7 @@ interface UtilContext {
   util: {
     flashMessage: (message, severity?) => void;
     confirmDialog: (message?) => Promise<boolean>;
+    promptDialog: (message, defaultValue?) => Promise<string>;
     setBackdrop: (loading: boolean) => void;
   };
 }

--- a/app/javascript/components/utils/gql.tsx
+++ b/app/javascript/components/utils/gql.tsx
@@ -5,12 +5,16 @@ const TASK_FRAGMENT = gql`
     id
     title
     description
-    deadline
+    priorityNumber
     done {
       id
       text
     }
-    priorityNumber
+    labels {
+      id
+      name
+    }
+    deadline
     createdAt
   }
 `;
@@ -61,6 +65,7 @@ export const GQL_CREATE_TASK = gql`
     $deadline: String
     $doneId: ID
     $priorityNumber: Int
+    $labelIds: [ID!]
   ) {
     createTask(
       input: {
@@ -69,6 +74,7 @@ export const GQL_CREATE_TASK = gql`
         deadline: $deadline
         doneId: $doneId
         priorityNumber: $priorityNumber
+        labelIds: $labelIds
       }
     ) {
       task {
@@ -87,6 +93,7 @@ export const GQL_UPDATE_TASK = gql`
     $deadline: String
     $doneId: ID
     $priorityNumber: Int
+    $labelIds: [ID!]
   ) {
     updateTask(
       input: {
@@ -96,6 +103,7 @@ export const GQL_UPDATE_TASK = gql`
         deadline: $deadline
         doneId: $doneId
         priorityNumber: $priorityNumber
+        labelIds: $labelIds
       }
     ) {
       task {
@@ -266,6 +274,55 @@ export const GQL_ADMIN_DELETE_USER = gql`
     adminDeleteUser(input: { id: $id }) {
       user {
         ...UserFragment
+      }
+    }
+  }
+`;
+
+const LABEL_FRAGMENT = gql`
+  fragment LabelFragment on Label {
+    id
+    name
+  }
+`;
+
+export const GQL_LABELS = gql`
+  ${LABEL_FRAGMENT}
+  query labels {
+    labels {
+      ...LabelFragment
+    }
+  }
+`;
+
+export const GQL_CREATE_LABEL = gql`
+  ${LABEL_FRAGMENT}
+  mutation createLabel($name: String!) {
+    createLabel(input: { name: $name }) {
+      labels {
+        ...LabelFragment
+      }
+    }
+  }
+`;
+
+export const GQL_UPDATE_LABEL = gql`
+  ${LABEL_FRAGMENT}
+  mutation updateLabel($id: ID!, $name: String!) {
+    updateLabel(input: { id: $id, name: $name }) {
+      labels {
+        ...LabelFragment
+      }
+    }
+  }
+`;
+
+export const GQL_DELETE_LABEL = gql`
+  ${LABEL_FRAGMENT}
+  mutation deleteLabel($id: ID!) {
+    deleteLabel(input: { id: $id }) {
+      labels {
+        ...LabelFragment
       }
     }
   }

--- a/app/javascript/components/utils/gql.tsx
+++ b/app/javascript/components/utils/gql.tsx
@@ -285,6 +285,7 @@ const LABEL_FRAGMENT = gql`
   fragment LabelFragment on Label {
     id
     name
+    tasksCount
   }
 `;
 

--- a/app/javascript/components/utils/gql.tsx
+++ b/app/javascript/components/utils/gql.tsx
@@ -288,8 +288,8 @@ const LABEL_FRAGMENT = gql`
 
 export const GQL_LABELS = gql`
   ${LABEL_FRAGMENT}
-  query labels {
-    labels {
+  query labels($userId: ID) {
+    labels(userId: $userId) {
       ...LabelFragment
     }
   }

--- a/app/javascript/components/utils/gql.tsx
+++ b/app/javascript/components/utils/gql.tsx
@@ -29,6 +29,7 @@ export const GQL_TASKS = gql`
     $sortType: String
     $isAsc: Boolean
     $target: String
+    $labelId: ID
   ) {
     tasks(
       userId: $userId
@@ -38,6 +39,7 @@ export const GQL_TASKS = gql`
       sortType: $sortType
       isAsc: $isAsc
       target: $target
+      labelId: $labelId
     ) {
       tasks {
         ...TaskFragment

--- a/app/javascript/components/utils/types.tsx
+++ b/app/javascript/components/utils/types.tsx
@@ -5,6 +5,11 @@ export type Done =
 
 export type PriorityNumber = 0 | 1 | 2;
 
+export interface Label {
+  id?: string;
+  name?: string;
+}
+
 export interface Task {
   id?: string;
   title?: string;
@@ -12,6 +17,7 @@ export interface Task {
   deadline?: string;
   done?: Done;
   priorityNumber?: PriorityNumber;
+  labels: Label[];
   createdAt?: string;
 }
 

--- a/app/javascript/components/utils/types.tsx
+++ b/app/javascript/components/utils/types.tsx
@@ -8,6 +8,7 @@ export type PriorityNumber = 0 | 1 | 2;
 export interface Label {
   id?: string;
   name?: string;
+  tasksCount?: number;
 }
 
 export interface Task {

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,0 +1,10 @@
+class Label < ApplicationRecord
+  has_many :task_labels, dependent: :destroy
+  has_many :tasks, through: :task_labels
+  belongs_to :user
+
+  with_options presence: true do
+    validates :user_id
+    validates :name, uniqueness: { scope: :user_id }
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,6 +9,14 @@ class Task < ApplicationRecord
   validates :done_id, inclusion: { in: Done.pluck(:id) }
   validates :priority_number, inclusion: { in: [0, 1, 2] }
 
+  def reset_labels(label_ids)
+    self.task_labels.destroy_all
+    return if label_ids.blank?
+    self.task_labels.create(
+      label_ids.map { |id| { label_id: id } }
+    )
+  end
+
   def self.search(word:, target:, done_ids:, sort_type:, is_asc:)
     sort_key = sort_type.underscore # スネークケースに変換
     sort_val = is_asc ? 'ASC' : 'DESC'

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,7 @@
 class Task < ApplicationRecord
   belongs_to :user
+  has_many :task_labels, dependent: :destroy
+  has_many :labels, through: :task_labels
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :done
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -17,11 +17,12 @@ class Task < ApplicationRecord
     )
   end
 
-  def self.search(word:, target:, done_ids:, sort_type:, is_asc:)
+  def self.search(word:, target:, done_ids:, sort_type:, is_asc:, label_id:)
     sort_key = sort_type.underscore # スネークケースに変換
     sort_val = is_asc ? 'ASC' : 'DESC'
     Task.
       filter_by_done_ids(done_ids).
+      filter_by_label(label_id).
       search_word("%#{word}%", target).
       order(sort_key => sort_val)
   end
@@ -43,5 +44,11 @@ class Task < ApplicationRecord
     return if done_ids.count == 3 # 全てのステータスの場合フィルタリング不要
 
     where(done_id: done_ids)
+  end
+
+  scope :filter_by_label, ->(label_id) do
+    return if label_id.blank? # 空の場合フィルタリング不要
+
+    where(id: TaskLabel.where(label_id: label_id).pluck(:task_id))
   end
 end

--- a/app/models/task_label.rb
+++ b/app/models/task_label.rb
@@ -1,0 +1,9 @@
+class TaskLabel < ApplicationRecord
+  belongs_to :task
+  belongs_to :label
+
+  with_options presence: true do
+    validates :task_id
+    validates :label_id, uniqueness: { scope: :task_id }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   attr_accessor :password, :password_confirmation
 
   has_many :tasks, dependent: :destroy
+  has_many :labels, dependent: :destroy
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :role
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,8 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require_relative '../lib/exception.rb'
+
 module MiyataniElTraining
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/db/migrate/20211126000636_create_labels.rb
+++ b/db/migrate/20211126000636_create_labels.rb
@@ -1,0 +1,10 @@
+class CreateLabels < ActiveRecord::Migration[6.1]
+  def change
+    create_table :labels do |t|
+      t.string :name, null: false
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :labels, [:user_id, :name], unique: true
+  end
+end

--- a/db/migrate/20211126000636_create_labels.rb
+++ b/db/migrate/20211126000636_create_labels.rb
@@ -5,6 +5,6 @@ class CreateLabels < ActiveRecord::Migration[6.1]
       t.references :user, null: false, foreign_key: true
       t.timestamps
     end
-    add_index :labels, [:user_id, :name], unique: true
+    add_index :labels, %i(user_id name), unique: true
   end
 end

--- a/db/migrate/20211126000746_create_task_labels.rb
+++ b/db/migrate/20211126000746_create_task_labels.rb
@@ -1,0 +1,10 @@
+class CreateTaskLabels < ActiveRecord::Migration[6.1]
+  def change
+    create_table :task_labels do |t|
+      t.references :task,  null: false, foreign_key: true
+      t.references :label, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :task_labels, [:task_id, :label_id], unique: true
+  end
+end

--- a/db/migrate/20211126000746_create_task_labels.rb
+++ b/db/migrate/20211126000746_create_task_labels.rb
@@ -5,6 +5,6 @@ class CreateTaskLabels < ActiveRecord::Migration[6.1]
       t.references :label, null: false, foreign_key: true
       t.timestamps
     end
-    add_index :task_labels, [:task_id, :label_id], unique: true
+    add_index :task_labels, %i(task_id label_id), unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_25_012311) do
+ActiveRecord::Schema.define(version: 2021_11_26_000746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "labels", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id", "name"], name: "index_labels_on_user_id_and_name", unique: true
+    t.index ["user_id"], name: "index_labels_on_user_id"
+  end
+
+  create_table "task_labels", force: :cascade do |t|
+    t.bigint "task_id", null: false
+    t.bigint "label_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["label_id"], name: "index_task_labels_on_label_id"
+    t.index ["task_id", "label_id"], name: "index_task_labels_on_task_id_and_label_id", unique: true
+    t.index ["task_id"], name: "index_task_labels_on_task_id"
+  end
 
   create_table "tasks", force: :cascade do |t|
     t.string "title", null: false
@@ -40,4 +59,7 @@ ActiveRecord::Schema.define(version: 2021_11_25_012311) do
     t.index ["name"], name: "index_users_on_name", unique: true
   end
 
+  add_foreign_key "labels", "users"
+  add_foreign_key "task_labels", "labels"
+  add_foreign_key "task_labels", "tasks"
 end

--- a/lib/exception.rb
+++ b/lib/exception.rb
@@ -1,0 +1,5 @@
+module Application
+  class AuthorizationError < StandardError; end
+
+  class AdminAuthorizationError < StandardError; end
+end

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "node": "16.13.0"
   },
   "scripts": {
-    "webpack": "bin/webpack-dev-server"
+    "webpack": "bin/webpack-dev-server",
+    "rspec": "HEADLESS=1 bundle exec rspec",
+    "deploy": "git branch --contains | awk '{print $2\":main\"}' | xargs git push --force-with-lease heroku"
   }
 }

--- a/spec/factories/labels.rb
+++ b/spec/factories/labels.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :label do
+    
+  end
+end

--- a/spec/factories/labels.rb
+++ b/spec/factories/labels.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :label do
-    
+    title { Faker::Lorem.sentence }
+    association :user
   end
 end

--- a/spec/factories/labels.rb
+++ b/spec/factories/labels.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :label do
-    title { Faker::Lorem.sentence }
+    name { Faker::Lorem.sentence }
     association :user
   end
 end

--- a/spec/factories/task_labels.rb
+++ b/spec/factories/task_labels.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :task_label do
+    
+  end
+end

--- a/spec/factories/task_labels.rb
+++ b/spec/factories/task_labels.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :task_label do
-    
+    association :task
+    association :label
   end
 end

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Label, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -1,5 +1,46 @@
 require 'rails_helper'
 
 RSpec.describe Label, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    let(:label) { FactoryBot.build(:label, user_id: user.id, **params) }
+    let(:user) { FactoryBot.create(:user) }
+    let(:another_user) { FactoryBot.create(:user) }
+    describe '正常系' do
+      subject { label }
+      context 'ラベル名がユニークな場合' do
+        let(:params) { { name: 'test' } }
+        it { is_expected.to be_valid }
+      end
+
+      context '同じラベル名を他のユーザーが使っている場合' do
+        before { FactoryBot.create(:label, user_id: another_user.id, **params) }
+
+        let(:params) { { name: 'test' } }
+        it { is_expected.to be_valid }
+      end
+    end
+
+    describe '異常系' do
+      subject {
+        label.valid?
+        label.errors.full_messages
+      }
+      context 'ラベル名が空の場合' do
+        let(:params) { { name: '' } }
+        it { is_expected.to include("Name can't be blank") }
+      end
+
+      context 'ユーザーが空の場合' do
+        let(:params) { { user_id: nil } }
+        it { is_expected.to include("User can't be blank") }
+      end
+
+      context 'ラベル名がユニークではない場合' do
+        before { FactoryBot.create(:label, user_id: user.id, **params) }
+
+        let(:params) { { name: 'test' } }
+        it { is_expected.to include('Name has already been taken') }
+      end
+    end
+  end
 end

--- a/spec/models/task_label_spec.rb
+++ b/spec/models/task_label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe TaskLabel, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/task_label_spec.rb
+++ b/spec/models/task_label_spec.rb
@@ -1,5 +1,58 @@
 require 'rails_helper'
 
 RSpec.describe TaskLabel, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーション' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:task) { FactoryBot.create(:task, user_id: user.id) }
+    let(:label) { FactoryBot.create(:label, user_id: user.id) }
+    let(:task_label) { FactoryBot.build(:task_label, task_id: task.id, label_id: label.id, **params) }
+    describe '正常系' do
+      let(:params) { {} }
+      context 'task_idとlabel_idが設定されている場合' do
+        subject { task_label }
+        it { is_expected.to be_valid }
+      end
+
+      context '別のタスクに設定済みのラベルを他のタスクに設定しようとした場合' do
+        subject {
+          another_task = FactoryBot.create(:task, user_id: user.id)
+          FactoryBot.create(:task_label, task_id: another_task.id, label_id: label.id)
+          task_label
+        }
+        it { is_expected.to be_valid }
+      end
+
+      context '別のラベルを設定済みのタスクに他のラベルを設定しようとした場合' do
+        subject {
+          another_label = FactoryBot.create(:label, user_id: user.id)
+          FactoryBot.create(:task_label, task_id: task.id, label_id: another_label.id)
+          task_label
+        }
+        it { is_expected.to be_valid }
+      end
+    end
+
+    describe '異常系' do
+      subject {
+        task_label.valid?
+        task_label.errors.full_messages
+      }
+      context 'task_idが空の場合' do
+        let(:params) { { task_id: nil } }
+        it { is_expected.to include("Task can't be blank") }
+      end
+
+      context 'label_idが空の場合' do
+        let(:params) { { label_id: nil } }
+        it { is_expected.to include("Label can't be blank") }
+      end
+
+      context '同じタスクに同じラベルを設定しようとした場合' do
+        before { FactoryBot.create(:task_label, task_id: task.id, label_id: label.id) }
+
+        let(:params) { {} }
+        it { is_expected.to include('Label has already been taken') }
+      end
+    end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -49,10 +49,7 @@ RSpec.describe Task, type: :model do
   describe '検索' do
     subject {
       create_tasks
-      Task.
-        search(word: '', target: 'all', done_ids: [-1, 0, 1], sort_type: 'created_at', is_asc: false, **params).
-        pluck(:id).
-        to_set
+      Task.search(user.id, params).pluck(:id).to_set
     }
     let(:create_tasks) {
       [

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,10 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.before(:each, type: :system) do |_example|
+    driven_by ENV.fetch('HEADLESS', false) ? :selenium_chrome_headless : :selenium_chrome
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/sign_in_module.rb
+++ b/spec/support/sign_in_module.rb
@@ -4,5 +4,6 @@ module SignInModule
     fill_in 'name', with: user.name
     fill_in 'password', with: user.password
     click_button 'ログイン'
+    sleep 0.5
   end
 end

--- a/spec/system/labels_spec.rb
+++ b/spec/system/labels_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe 'Labels', type: :system do
       subject {
         visit '/tasks/new'
         find('[data-testid="EditIcon"]').click
-        accept_prompt(with: label.name) { click_button '新しいラベルを作成' }
+        click_button '新しいラベルを作成'
+        fill_in 'prompt', with: label.name
+        click_button '決定'
         page
       }
       let(:label) { FactoryBot.build(:label, user_id: user.id) }
@@ -28,9 +30,9 @@ RSpec.describe 'Labels', type: :system do
         label_before
         visit '/tasks/new'
         find('[data-testid="EditIcon"]').click
-        accept_prompt(with: label_after.name) {
-          find("[data-test-label='#{label_before.id}'] [data-testid='EditIcon']").click
-        }
+        find("[data-test-label='#{label_before.id}'] [data-testid='EditIcon']").click
+        fill_in 'prompt', with: label_after.name
+        click_button '決定'
         page
       }
       let(:label_before) { FactoryBot.create(:label, user_id: user.id) }

--- a/spec/system/labels_spec.rb
+++ b/spec/system/labels_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe 'Labels', type: :system do
+  describe 'Labels' do
+    before { sign_in_as(user) }
+
+    let(:user) { FactoryBot.create(:user) }
+    let(:subject_sleep) {
+      subject
+      sleep 0.5
+    }
+
+    describe 'ラベル作成' do
+      subject {
+        visit '/tasks/new'
+        find('[data-testid="EditIcon"]').click
+        accept_prompt(with: label.name) { click_button '新しいラベルを作成' }
+        page
+      }
+      let(:label) { FactoryBot.build(:label, user_id: user.id) }
+      it { is_expected.to have_content('ラベルを作成しました') }
+      it { is_expected.to have_content(label.name) }
+      it { expect { subject_sleep }.to change { user.labels.count }.from(0).to(1) }
+    end
+
+    describe 'ラベル編集' do
+      subject {
+        label_before
+        visit '/tasks/new'
+        find('[data-testid="EditIcon"]').click
+        accept_prompt(with: label_after.name) {
+          find("[data-test-label='#{label_before.id}'] [data-testid='EditIcon']").click
+        }
+        page
+      }
+      let(:label_before) { FactoryBot.create(:label, user_id: user.id) }
+      let(:label_after) { FactoryBot.build(:label, user_id: user.id) }
+      it { is_expected.to have_content('ラベル名を変更しました') }
+      it { is_expected.to have_no_content(label_before.name) }
+      it { is_expected.to have_content(label_after.name) }
+    end
+
+    describe 'ラベル削除' do
+      subject {
+        visit '/tasks/new'
+        find('[data-testid="EditIcon"]').click
+        find("[data-test-label='#{label.id}'] [data-testid='DeleteIcon']").click
+        sleep 1
+        click_button 'はい'
+        page
+      }
+      let!(:label) { FactoryBot.create(:label, user_id: user.id) }
+      it { is_expected.to have_content('ラベルを削除しました') }
+      it { is_expected.to have_no_content(label.name) }
+      it { expect { subject_sleep }.to change { user.labels.count }.from(1).to(0) }
+    end
+
+    describe 'ラベル一覧' do
+      subject {
+        visit '/'
+        find('[data-test-label-list]').click
+        page
+      }
+      let!(:labels) { FactoryBot.create_list(:label, 5, user_id: user.id) }
+      it {
+        subject
+        expect(page).to have_content(labels[0].name)
+        expect(page).to have_content(labels[3].name)
+      }
+    end
+  end
+end

--- a/spec/system/task_labels_spec.rb
+++ b/spec/system/task_labels_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'TaskLabels', type: :system do
+  describe 'TaskLabels' do
+    before {
+      task
+      label
+      sign_in_as(user)
+    }
+
+    let(:user) { FactoryBot.create(:user) }
+    let(:task) { FactoryBot.create(:task, user_id: user.id) }
+    let(:label) { FactoryBot.create(:label, user_id: user.id) }
+    let(:subject_sleep) {
+      subject
+      sleep 0.5
+    }
+    describe 'ラベル設定' do
+      subject {
+        find('[data-testid="EditIcon"]').click
+        find("[data-test-label='#{label.id}'] .MuiCheckbox-root").click
+        click_button 'OK'
+        page
+      }
+      it { is_expected.to have_content('ラベルを設定しました') }
+      it { is_expected.to have_content(label.name) }
+      it { expect { subject_sleep }.to change { task.task_labels.count }.from(0).to(1) }
+    end
+
+    describe 'ラベル設定解除' do
+      subject {
+        visit '/'
+        find('[data-testid="EditIcon"]').click
+        find("[data-test-label='#{label.id}'] .MuiCheckbox-root").click
+        click_button 'OK'
+        page
+      }
+      before { FactoryBot.create(:task_label, task_id: task.id, label_id: label.id) }
+
+      it { is_expected.to have_content('ラベルを設定しました') }
+      it { is_expected.to have_no_content(label.name) }
+      it { expect { subject_sleep }.to change { task.task_labels.count }.from(1).to(0) }
+    end
+  end
+end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe 'Tasks', type: :system do
     end
 
     let(:user) { FactoryBot.create(:user) }
+    let(:subject_sleep) {
+      subject
+      sleep 1
+    }
     describe 'タスクの作成' do
       let(:task) { FactoryBot.build(:task, user_id: user.id) }
 
@@ -27,13 +31,7 @@ RSpec.describe 'Tasks', type: :system do
           click_button '投稿'
           page
         }
-        it {
-          expect {
-            subject
-            sleep 1
-          }.to change { Task.count }.from(0).to(1)
-        }
-
+        it { expect { subject_sleep }.to change { Task.count }.from(0).to(1) }
         it { is_expected.to have_current_path('/') }
         it { is_expected.to have_content('タスクを投稿しました') }
 
@@ -50,13 +48,7 @@ RSpec.describe 'Tasks', type: :system do
           click_button '投稿'
         }
         it { is_expected.to have_no_content('タイトルを入力してください') }
-
-        it {
-          expect {
-            subject
-            sleep 1
-          }.not_to(change { Task.count })
-        }
+        it { expect { subject_sleep }.not_to(change { Task.count }) }
       end
 
       describe '入力するがキャンセル' do
@@ -67,12 +59,7 @@ RSpec.describe 'Tasks', type: :system do
           click_link 'キャンセル'
           page
         }
-        it {
-          expect {
-            subject
-            sleep 1
-          }.not_to(change { Task.count })
-        }
+        it { expect { subject_sleep }.not_to(change { Task.count }) }
 
         it '投稿されたタスクがタスク一覧に表示されている' do
           subject
@@ -89,6 +76,7 @@ RSpec.describe 'Tasks', type: :system do
 
       describe 'タスク一覧の編集ボタンをクリック' do
         subject {
+          visit '/'
           click_link '編集' # 編集ページへ
           page
         }
@@ -109,13 +97,7 @@ RSpec.describe 'Tasks', type: :system do
           click_button '更新'
           page
         }
-        it {
-          expect {
-            subject
-            sleep 1
-          }.not_to(change { Task.count })
-        }
-
+        it { expect { subject_sleep }.not_to(change { Task.count }) }
         it { is_expected.to have_current_path('/') }
         it { is_expected.to have_content('タスクを更新しました') }
 
@@ -140,13 +122,7 @@ RSpec.describe 'Tasks', type: :system do
           click_link 'キャンセル'
           page
         }
-        it {
-          expect {
-            subject
-            sleep 1
-          }.not_to(change { Task.count })
-        }
-
+        it { expect { subject_sleep }.not_to(change { Task.count }) }
         it { is_expected.to have_current_path('/') }
 
         it 'タスク一覧のタスクが更新されていない' do
@@ -177,14 +153,7 @@ RSpec.describe 'Tasks', type: :system do
           click_button 'はい'
           page
         }
-
-        it {
-          expect {
-            subject
-            sleep 1
-          }.to change { Task.count }.from(1).to(0)
-        }
-
+        it { expect { subject_sleep }.to change { Task.count }.from(1).to(0) }
         it { is_expected.to have_content('タスクが削除されました') }
 
         it 'タスク一覧から削除されたタスクが消えている' do
@@ -200,13 +169,7 @@ RSpec.describe 'Tasks', type: :system do
           click_button 'いいえ'
           page
         }
-
-        it {
-          expect {
-            subject
-            sleep 1
-          }.not_to(change { Task.count })
-        }
+        it { expect { subject_sleep }.not_to(change { Task.count }) }
 
         it 'タスク一覧から削除をキャンセルしたタスクが消えていない' do
           subject
@@ -227,6 +190,7 @@ RSpec.describe 'Tasks', type: :system do
 
       context 'ページ表示直後' do
         subject {
+          visit '/'
           sleep 1
           page.body
         }
@@ -311,11 +275,15 @@ RSpec.describe 'Tasks', type: :system do
           click_button 'search'
           page
         }
-        it { is_expected.to have_content(tasks[0].title) }
-        it { is_expected.to have_no_content(tasks[1].title) }
-        it { is_expected.to have_no_content(tasks[2].title) }
-        it { is_expected.to have_no_content(tasks[3].title) }
-        it { is_expected.to have_content(tasks[4].title) }
+        it {
+          subject
+          [0, 4].each do |i|
+            expect(page).to have_content(tasks[i].title)
+          end
+          [1, 2, 3].each do |i|
+            expect(page).to have_no_content(tasks[i].title)
+          end
+        }
       end
 
       describe '内容のキーワード検索＆ステータス着手・完了で検索' do
@@ -326,25 +294,31 @@ RSpec.describe 'Tasks', type: :system do
           click_button 'search'
           page
         }
-        it { is_expected.to have_no_content(tasks[0].title) }
-        it { is_expected.to have_content(tasks[1].title) }
-        it { is_expected.to have_no_content(tasks[2].title) }
-        it { is_expected.to have_content(tasks[3].title) }
-        it { is_expected.to have_no_content(tasks[4].title) }
+        it {
+          subject
+          [1, 3].each do |i|
+            expect(page).to have_content(tasks[i].title)
+          end
+          [0, 2, 4].each do |i|
+            expect(page).to have_no_content(tasks[i].title)
+          end
+        }
       end
     end
 
     describe 'ページネーション' do
-      let!(:tasks) {
+      before {
+        tasks
+        visit '/'
+      }
+
+      let(:tasks) {
         (0...20).
           map { |i| { created_at: Time.current.ago(i.days) } }.
           map { |args| FactoryBot.create(:task, user_id: user.id, **args) }
       }
-
       describe 'タスク一覧1ページ目' do
-        subject {
-          page
-        }
+        subject { page }
         it '10件のタスクのみ表示されている' do
           subject
           expect(page.all('.task-card').count).to eq 10
@@ -352,14 +326,16 @@ RSpec.describe 'Tasks', type: :system do
 
         it '最新10件が表示されている' do
           subject
-          expect(page).to have_content(tasks[0].title)
-          expect(page).to have_content(tasks[9].title)
+          (0..9).each do |i|
+            expect(page).to have_content(tasks[i].title)
+          end
         end
 
         it '最新10件以外のタスクが表示されていない' do
           subject
-          expect(page).to have_no_content(tasks[10].title)
-          expect(page).to have_no_content(tasks[19].title)
+          (10..19).each do |i|
+            expect(page).to have_no_content(tasks[i].title)
+          end
         end
       end
 
@@ -370,14 +346,16 @@ RSpec.describe 'Tasks', type: :system do
         }
         it '最新11-20件が表示されている' do
           subject
-          expect(page).to have_content(tasks[10].title)
-          expect(page).to have_content(tasks[19].title)
+          (10..19).each do |i|
+            expect(page).to have_content(tasks[i].title)
+          end
         end
 
         it '最新11-20件以外のタスクが表示されていない' do
           subject
-          expect(page).to have_no_content(tasks[0].title)
-          expect(page).to have_no_content(tasks[9].title)
+          (0..9).each do |i|
+            expect(page).to have_no_content(tasks[i].title)
+          end
         end
       end
     end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -309,6 +309,7 @@ RSpec.describe 'Tasks', type: :system do
     describe 'ページネーション' do
       before {
         tasks
+        sleep 1
         visit '/'
       }
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe 'Users', type: :system do
   describe '一般ユーザー' do
     before { FactoryBot.create(:user, role_id: Role::ADMIN) }
 
+    let(:subject_sleep) {
+      subject
+      sleep 1
+    }
     describe '新規登録' do
       let(:user) { FactoryBot.build(:user) }
 
@@ -25,13 +29,7 @@ RSpec.describe 'Users', type: :system do
           click_button '登録'
           page
         }
-        it {
-          expect {
-            subject
-            sleep 1
-          }.to change { User.count }.from(1).to(2)
-        }
-
+        it { expect { subject_sleep }.to change { User.count }.from(1).to(2) }
         it { is_expected.to have_current_path('/') }
         it { is_expected.to have_content('タスク作成') }
       end
@@ -78,13 +76,7 @@ RSpec.describe 'Users', type: :system do
           click_button 'はい'
           page
         }
-        it {
-          expect {
-            subject
-            sleep 1
-          }.to change { User.count }.from(2).to(1)
-        }
-
+        it { expect { subject_sleep }.to change { User.count }.from(2).to(1) }
         it { is_expected.to have_no_content('タスク作成') }
         it { is_expected.to have_content('ログイン') }
       end


### PR DESCRIPTION
* タスクに複数のラベルをつけられるようにしました。
  * 複数のラベルをつけられるようにする為にタスクとラベルの中間テーブルを作成しています。
  * ラベルの作成・編集・削除・タスクへの設定・解除はタスクの投稿画面とタスク一覧画面で、ラベル設定用の編集ボタンからできるようにしました。
  * https://gyazo.com/5fde1e35bae9c1a3e467d758ae4a1dcc
  * https://gyazo.com/d0b7f146005a2d7298ddff27df5ac61b
* Graphqlの共通処理を分離して、リファクタリングを行いました。
  * こういう場合の切り出し先がよく分からなかったのですが、ヘルパーを利用してみました。
  * ヘルパーをBaseMutationやBaseResolver・QueryTypeにincludeしました。

RSpec を拡充し、heroku も最新の状態に更新しました。

- heroku: https://miyatani-el-training.herokuapp.com/
  - 【一般ユーザー】 ユーザー名: `test`, パスワード: `abc123`
  - 【管理ユーザー】 ユーザー名: `admin`, パスワード: `abc123`

よろしくおねがいします！