### PR TITLE
Step25: エラーページを設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,7 @@
 class ApplicationController < ActionController::Base
+  rescue_from StandardError, with: :error500_redirect
+
+  def error500_redirect(_exception = nil)
+    redirect_to '/error500'
+  end
 end

--- a/app/controllers/react_controller.rb
+++ b/app/controllers/react_controller.rb
@@ -1,4 +1,12 @@
 class ReactController < ApplicationController
   def index
   end
+
+  def error500
+    render action: :index, status: :internal_server_error
+  end
+
+  def test500
+    raise StandardError
+  end
 end

--- a/app/javascript/components/MyRouter.tsx
+++ b/app/javascript/components/MyRouter.tsx
@@ -12,6 +12,8 @@ import AdminTop from 'page/AdminTop';
 import AdminUserCreate from 'page/AdminUserCreate';
 import AdminUserUpdate from 'page/AdminUserUpdate';
 import AdminUserTasks from 'page/AdminUserTasks';
+import Error404 from 'page/Error404';
+import Error500 from 'page/Error500';
 
 const MyRouter = () => {
   const { isLogin } = useContext(UserContext);
@@ -28,6 +30,8 @@ const MyRouter = () => {
         <Route path="/admin/users/new" element={<AdminUserCreate />} />
         <Route path="/admin/users/:id/edit" element={<AdminUserUpdate />} />
         <Route path="/admin/users/:id/tasks" element={<AdminUserTasks />} />
+        <Route path="/error500" element={<Error500 />} />
+        <Route path="*" element={<Error404 />} />
       </Routes>
     </BrowserRouter>
   );

--- a/app/javascript/components/hooks/useMutationEx.tsx
+++ b/app/javascript/components/hooks/useMutationEx.tsx
@@ -14,8 +14,9 @@ const useMutationEx: useMutationEx = (mutation, options) => {
     if (options.onError) return;
     if (!error) return;
     console.error(error);
-    alert(
-      '申し訳ございません、エラーが発生しました。ページを再読み込みしてください。'
+    util.flashMessage(
+      '申し訳ございません、エラーが発生しました。ページを再読み込みしてください。',
+      'error'
     );
   }, [error]);
 

--- a/app/javascript/components/hooks/useQueryEx.tsx
+++ b/app/javascript/components/hooks/useQueryEx.tsx
@@ -13,8 +13,9 @@ const useQueryEx: useQueryEx = (query, options) => {
   useEffect(() => {
     if (!error) return;
     console.error(error);
-    alert(
-      '申し訳ございません、エラーが発生しました。ページを再読み込みしてください。'
+    util.flashMessage(
+      '申し訳ございません、エラーが発生しました。ページを再読み込みしてください。',
+      'error'
     );
   }, [error]);
 

--- a/app/javascript/components/page/Error404.tsx
+++ b/app/javascript/components/page/Error404.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import BaseLayout from 'BaseLayout';
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import Button from '@mui/material/Button';
+import { Link } from 'react-router-dom';
+
+const Error404 = () => {
+  return (
+    <BaseLayout>
+      <Container component="main" sx={{ mt: 8, mb: 2 }} maxWidth="sm">
+        <Typography variant="h3" component="h1" gutterBottom>
+          404 Page Not Found
+        </Typography>
+        <Typography variant="h5" component="h2" gutterBottom>
+          申し訳ございません。 <br />
+          リクエストされたページは見つかりませんでした。
+        </Typography>
+        <Typography variant="body1" sx={{ textAlign: 'center' }}>
+          <Button variant="contained" color="primary" component={Link} to="/">
+            トップページへ
+          </Button>
+        </Typography>
+      </Container>
+    </BaseLayout>
+  );
+};
+
+export default Error404;

--- a/app/javascript/components/page/Error500.tsx
+++ b/app/javascript/components/page/Error500.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import BaseLayout from 'BaseLayout';
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import Button from '@mui/material/Button';
+import { Link } from 'react-router-dom';
+
+const Error500 = () => {
+  return (
+    <BaseLayout>
+      <Container component="main" sx={{ mt: 8, mb: 2 }} maxWidth="sm">
+        <Typography variant="h3" component="h1" gutterBottom>
+          500 Internal Server Error
+        </Typography>
+        <Typography variant="h5" component="h2" gutterBottom>
+          申し訳ございません。 <br />
+          リクエストされたページは表示できませんでした。
+        </Typography>
+        <Typography variant="body1" sx={{ textAlign: 'center' }}>
+          <Button variant="contained" color="primary" component={Link} to="/">
+            トップページへ
+          </Button>
+        </Typography>
+      </Container>
+    </BaseLayout>
+  );
+};
+
+export default Error500;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
     mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql'
   end
 
+  get '/error500', to: 'react#error500'
+  get '/test500',  to: 'react#test500'
+
   root to: 'react#index'
   get '*path', to: 'react#index'
 end

--- a/spec/system/tasks_spec.rb
+++ b/spec/system/tasks_spec.rb
@@ -309,6 +309,7 @@ RSpec.describe 'Tasks', type: :system do
     describe 'ページネーション' do
       before {
         tasks
+        sleep 1
         visit '/'
       }
 


### PR DESCRIPTION
* 404と500のエラーページを作成しました。
  * 404のエラーページはReactRouterの`path="*"`を利用して作成しました。
  * 500のエラーページに関してはSPAだとAPI上でしか起こることが無さそうかなと思いましたが、強制的にエラーを起こすページ[/test500](https://miyatani-el-training.herokuapp.com/test500)を作成し、エラーが起きるとcatchして[/error500](https://miyatani-el-training.herokuapp.com/error500)にリダイレクトしてReactRouterの`path="/error500"`で500のエラーぺージを表示するという風にしてみました。

- heroku: https://miyatani-el-training.herokuapp.com/
  - 【一般ユーザー】 ユーザー名: `test`, パスワード: `abc123`
  - 【管理ユーザー】 ユーザー名: `admin`, パスワード: `abc123`

よろしくお願いします！
